### PR TITLE
Downgrade the minimum dependency versions.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,9 +13,9 @@ license_file = LICENSE
 packages =
     heisenbridge
 install_requires =
-  aiohttp >=3.7.4.post0, <3.8
-  irc >=19.0.1, <20.0
-  pyyaml >=5.4, <5.5
+  aiohttp >=3.6, <3.8
+  irc >=19.0.0, <20.0
+  pyyaml >=5.3, <5.5
 
 python_requires = >=3.6
 


### PR DESCRIPTION
I tried to package heisenbridge against my nixos-stable system libraries. I downgraded the library requirements a little across the board to make each of them fit my system and it didn't break anything that I tested (after days in use).