### PR TITLE
Plumb invite-only rooms

### DIFF
--- a/heisenbridge/__main__.py
+++ b/heisenbridge/__main__.py
@@ -78,6 +78,9 @@ class BridgeAppService(AppService):
 
         return False
 
+    def is_local(self, mxid: str):
+        return mxid.endswith(":" + self.server.name)
+
     def strip_nick(self, nick: str) -> Tuple[str, str]:
         m = re.match(r"^([~&@%\+]?)(.+)$", nick)
         if m:
@@ -158,6 +161,10 @@ class BridgeAppService(AppService):
             and event["user_id"] != self.user_id
             and event["content"]["membership"] == "invite"
         ):
+            if "is_direct" not in event["content"] or event["content"]["is_direct"] is not True:
+                logging.debug("Got an invite to non-direct room, ignoring")
+                return
+
             logging.info(f"Got an invite from {event['user_id']}")
 
             # only respond to an invite

--- a/heisenbridge/matrix.py
+++ b/heisenbridge/matrix.py
@@ -113,6 +113,9 @@ class Matrix:
     async def get_room_joined_members(self, room_id):
         return await self.call("GET", "/_matrix/client/r0/rooms/" + room_id + "/joined_members")
 
+    async def get_room_state_event(self, room_id, event_type, state_key=""):
+        return await self.call("GET", "/_matrix/client/r0/rooms/" + room_id + "/state/" + event_type + "/" + state_key)
+
     async def post_room_join(self, room_id, user_id=None):
         return await self.call(
             "POST",

--- a/heisenbridge/plumbed_room.py
+++ b/heisenbridge/plumbed_room.py
@@ -26,6 +26,7 @@ class PlumbedRoom(ChannelRoom):
 
         try:
             resp = await network.serv.api.post_room_join_alias(id)
+            join_rules = await network.serv.api.get_room_state_event(id, "m.room.join_rules")
         except MatrixError as e:
             network.send_notice(f"Failed to join room: {str(e)}")
             return
@@ -35,6 +36,7 @@ class PlumbedRoom(ChannelRoom):
         room.key = key
         room.network = network
         room.network_name = network.name
+        room.need_invite = join_rules["join_rule"] != "public"
 
         network.serv.register_room(room)
         network.rooms[room.name] = room


### PR DESCRIPTION
Also makes puppet joining slightly more robust with a retry
mechanism.

Does not take into account an edge case where the room join rules
have changed while the bridge is offline. Toggling them will
refersh the bridge state.