### PR TITLE
Configure heisenbridge entrypoint

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,10 @@ install_requires =
 
 python_requires = >=3.6
 
+[options.entry_points]
+console_scripts =
+    heisenbridge = heisenbridge.__main__:main
+
 [options.extras_require]
 dev =
     mypy


### PR DESCRIPTION
This change will put an executable in the bin/ output of the package
that can be put into the PATH variable for easier execution.

The `python -m heisenbridge` call will still work, because `main()` will automatically be called.