### PR TITLE
Global ident override configuration

### DIFF
--- a/heisenbridge/__main__.py
+++ b/heisenbridge/__main__.py
@@ -375,7 +375,7 @@ class BridgeAppService(AppService):
         self._users = {}
         self.user_id = whoami["user_id"]
         self.server_name = self.user_id.split(":")[1]
-        self.config = {"networks": {}, "owner": None, "allow": {}}
+        self.config = {"networks": {}, "owner": None, "allow": {}, "idents": {}}
         logging.debug(f"Default config: {self.config}")
         self.synapse_admin = False
 

--- a/heisenbridge/identd.py
+++ b/heisenbridge/identd.py
@@ -49,9 +49,7 @@ class Identd:
                         remote_addr = ipaddress.ip_address("::ffff:" + _remote_addr)
 
                     if remote_addr == req_addr and remote_port == dst_port and local_port == src_port:
-                        username = room.get_username()
-                        if username is not None:
-                            response = f"{src_port}, {dst_port} : USERID : UNIX : {username}\r\n"
+                        response = f"{src_port}, {dst_port} : USERID : UNIX : {room.get_ident()}\r\n"
                         break
 
                 logging.debug(f"Responding with: {response}")


### PR DESCRIPTION
Allow admin to set ident overrides for any mxid, default to hash.

Fixes #116