### PR TITLE
Lazy join IRC users, defaults to on join and talk

### DIFF
--- a/heisenbridge/__main__.py
+++ b/heisenbridge/__main__.py
@@ -375,7 +375,7 @@ class BridgeAppService(AppService):
         self._users = {}
         self.user_id = whoami["user_id"]
         self.server_name = self.user_id.split(":")[1]
-        self.config = {"networks": {}, "owner": None, "allow": {}, "idents": {}}
+        self.config = {"networks": {}, "owner": None, "allow": {}, "idents": {}, "member_sync": "half"}
         logging.debug(f"Default config: {self.config}")
         self.synapse_admin = False
 
@@ -448,7 +448,7 @@ class BridgeAppService(AppService):
 
                 # add to room displayname
                 for user_id, data in joined_members.items():
-                    if data["display_name"] is not None:
+                    if "display_name" in data and data["display_name"] is not None:
                         room.displaynames[user_id] = data["display_name"]
 
                     # add to global puppet cache if it's a puppet

--- a/heisenbridge/network_room.py
+++ b/heisenbridge/network_room.py
@@ -323,6 +323,7 @@ class NetworkRoom(Room):
             action="store_false",
             help="Disable displaynames for relaybot mode",
         )
+        cmd.add_argument("--sync", choices=["off", "lazy", "half", "full"], help="Set member sync for room")
         cmd.set_defaults(max_lines=None, pastebin=None, displaynames=None)
         self.commands.register(cmd, self.cmd_plumbcfg)
 
@@ -563,6 +564,11 @@ class NetworkRoom(Room):
         if args.displaynames is not None:
             room.use_displaynames = args.displaynames
             self.send_notice(f"Displaynames set to {args.displaynames}.")
+            save = True
+
+        if args.sync is not None:
+            room.member_sync = args.sync
+            self.send_notice(f"Member sync set to {args.sync}.")
             save = True
 
         if save:

--- a/heisenbridge/plumbed_room.py
+++ b/heisenbridge/plumbed_room.py
@@ -46,7 +46,7 @@ class PlumbedRoom(ChannelRoom):
         for user_id, data in joined_members.items():
             if user_id not in room.members:
                 room.members.append(user_id)
-            if data["display_name"] is not None:
+            if "display_name" in data and data["display_name"] is not None:
                 room.displaynames[user_id] = data["display_name"]
 
         network.serv.register_room(room)


### PR DESCRIPTION
- full: all member updated will be synced
- half: all new member updates after joining will be synced or if
  someone talks (new default)
- lazy: only talking members are synced
- off: disable all member synchronization during spam attacks

Bridge admin can set the default and it can be overridden per room.

This is a breaking change as it will change how new rooms behave
unless you change the new default back to "full".

Closes #112