### PR TITLE
Quarantine recently redacted media

### DIFF
--- a/heisenbridge/channel_room.py
+++ b/heisenbridge/channel_room.py
@@ -102,14 +102,7 @@ class ChannelRoom(PrivateRoom):
         self.bans_buffer = []
 
     def from_config(self, config: dict) -> None:
-        if "name" not in config:
-            raise Exception("No name key in config for ChatRoom")
-
-        if "network" not in config:
-            raise Exception("No network key in config for ChatRoom")
-
-        self.name = config["name"]
-        self.network_name = config["network"]
+        super().from_config(config)
 
         if "key" in config:
             self.key = config["key"]
@@ -118,7 +111,7 @@ class ChannelRoom(PrivateRoom):
             self.member_sync = config["member_sync"]
 
     def to_config(self) -> dict:
-        return {"name": self.name, "network": self.network_name, "key": self.key, "member_sync": self.member_sync}
+        return {**(super().to_config()), "key": self.key, "member_sync": self.member_sync}
 
     @staticmethod
     def create(network: NetworkRoom, name: str) -> "ChannelRoom":

--- a/heisenbridge/matrix.py
+++ b/heisenbridge/matrix.py
@@ -282,3 +282,8 @@ class Matrix:
 
     async def post_synapse_admin_room_join(self, room_id, user_id):
         return await self.call("POST", f"/_synapse/admin/v1/join/{room_id}", {"user_id": user_id})
+
+    async def post_synapse_admin_media_quarantine(self, server_name, media_id):
+        server_name = urllib.parse.quote(server_name, safe="")
+        media_id = urllib.parse.quote(media_id, safe="")
+        return await self.call("POST", f"/_synapse/admin/v1/media/quarantine/{server_name}/{media_id}")

--- a/heisenbridge/plumbed_room.py
+++ b/heisenbridge/plumbed_room.py
@@ -156,6 +156,8 @@ class PlumbedRoom(ChannelRoom):
                 "<{}> {}".format(sender, self.serv.mxc_to_url(event["content"]["url"], event["content"]["body"])),
             )
             self.react(event["event_id"], "\U0001F517")  # link
+            self.media.append([event["event_id"], event["content"]["url"]])
+            await self.save()
         elif event["content"]["msgtype"] == "m.emote":
             await self._send_message(event, self.network.conn.action, prefix=f"{sender} ")
         elif event["content"]["msgtype"] == "m.text":


### PR DESCRIPTION
If we are an admin on Synapse, quarantine recent media removed by
bridge users.

This only works for recent uploads and is by no means reliable but
it's something.

Fixes #120, kind of.