### PR TITLE
RELAYMSG sending support

### DIFF
--- a/heisenbridge/network_room.py
+++ b/heisenbridge/network_room.py
@@ -135,7 +135,7 @@ class NetworkRoom(Room):
         self.tls_cert = None
         self.rejoin_invite = True
         self.rejoin_kick = False
-        self.caps = ["chghost"]
+        self.caps = ["message-tags", "chghost"]
         self.backoff = 0
         self.backoff_task = None
         self.next_server = 0
@@ -464,7 +464,9 @@ class NetworkRoom(Room):
             description="request server capabilities on connect",
             epilog="Only bridge supported capabilities can be requested.",
         )
-        cmd.add_argument("--add", nargs=1, choices=["chghost"], help="Add to CAP request")
+        cmd.add_argument(
+            "--add", nargs=1, choices=["message-tags", "chghost", "draft/relaymsg"], help="Add to CAP request"
+        )
         cmd.add_argument("--remove", nargs=1, help="Remove from CAP request")
         cmd.set_defaults(add=None, remove=None)
         self.commands.register(cmd, self.cmd_caps)

--- a/heisenbridge/private_room.py
+++ b/heisenbridge/private_room.py
@@ -379,6 +379,12 @@ class PrivateRoom(Room):
 
         (plain, formatted) = parse_irc_formatting(event.arguments[0], self.pills())
 
+        # ignore relaymsgs by us
+        if event.tags:
+            for tag in event.tags:
+                if tag["key"] == "draft/relaymsg" and tag["value"] == self.network.conn.real_nickname:
+                    return
+
         if event.source.nick == self.network.conn.real_nickname:
             self.send_message(f"You said: {plain}", formatted=(f"You said: {formatted}" if formatted else None))
             return
@@ -427,6 +433,12 @@ class PrivateRoom(Room):
     def on_ctcp(self, conn, event) -> None:
         if self.network is None:
             return
+
+        # ignore relaymsgs by us
+        if event.tags:
+            for tag in event.tags:
+                if tag["key"] == "draft/relaymsg" and tag["value"] == self.network.conn.real_nickname:
+                    return
 
         irc_user_id = self.serv.irc_user_id(self.network.name, event.source.nick)
 


### PR DESCRIPTION
We are now draft/relaymsg aware enough to send them and filter out
our own relayed messages.

The tag after relayed name defaults to "m" and is configurable with
RELAYTAG plumbed room command.