### PR TITLE
Add example commands to join network

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,15 @@ Install
    python -m heisenbridge -c /path/to/synapse/config/heisenbridge.yaml
    ```
 
-7. Start a DM with `@heisenbridge:your.homeserver` to get online usage help
+7. Start a DM with `@heisenbridge:your.homeserver` to get online usage help. Example commands to join a new network:
+
+   ```bash
+   ADDNETWORK freenode
+   ADDSERVER freenode chat.freenode.net 7000 --tls
+   OPEN freenode
+   ```
+
+   You will be invited to a room where you can `CONNECT` and `JOIN #some-channel`
 
 To update your installation, run `pip install --upgrade heisenbridge`
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Install
 
 7. Start a DM with `@heisenbridge:your.homeserver` to get online usage help. Example commands to join a new network:
 
-   ```bash
+   ```
    ADDNETWORK freenode
    ADDSERVER freenode chat.freenode.net 7000 --tls
    OPEN freenode

--- a/README.md
+++ b/README.md
@@ -197,9 +197,9 @@ Install
 7. Start a DM with `@heisenbridge:your.homeserver` to get online usage help. Example commands to join a new network:
 
    ```
-   ADDNETWORK freenode
-   ADDSERVER freenode chat.freenode.net 7000 --tls
-   OPEN freenode
+   ADDNETWORK IRCnet
+   ADDSERVER IRCnet ssl.ircnet.io 6697 --tls
+   OPEN IRCnet
    ```
 
    You will be invited to a room where you can `CONNECT` and `JOIN #some-channel`


### PR DESCRIPTION
I think a quick "_type these 5 commands_" are nice to have in the readme for newcomers

(I can change freenode to `irc.example.com` if you rather want "dummy data" in the readme)