### PR TITLE
add handler to ignore tagmsg

### DIFF
--- a/heisenbridge/network_room.py
+++ b/heisenbridge/network_room.py
@@ -1354,6 +1354,9 @@ class NetworkRoom(Room):
                 self.conn.add_global_handler("away", self.on_away)
                 self.conn.add_global_handler("endofwhois", self.on_endofwhois)
 
+                # tags
+                self.conn.add_global_handler("tagmsg", self.on_pass_or_ignore)
+
                 # generated
                 self.conn.add_global_handler("ctcp", self.on_ctcp)
                 self.conn.add_global_handler("ctcpreply", self.on_ctcpreply)


### PR DESCRIPTION
I expect this will add a handler to ignore the `tagmsg` events that are causing #216.