### PR TITLE
Make MAXLINES and PASTEBIN setting more globally available

### DIFF
--- a/heisenbridge/__main__.py
+++ b/heisenbridge/__main__.py
@@ -490,6 +490,8 @@ class BridgeAppService(AppService):
             "allow": {},
             "idents": {},
             "member_sync": "half",
+            "max_lines": 0,
+            "use_pastebin": True,
             "media_url": None,
             "namespace": self.puppet_prefix,
         }

--- a/heisenbridge/channel_room.py
+++ b/heisenbridge/channel_room.py
@@ -184,6 +184,9 @@ class ChannelRoom(PrivateRoom):
         # stamp global member sync setting at room creation time
         room.member_sync = network.serv.config["member_sync"]
 
+        room.max_lines = network.serv.config["max_lines"]
+        room.use_pastebin = network.serv.config["use_pastebin"]
+
         asyncio.ensure_future(room._create_mx(name))
         return room
 

--- a/heisenbridge/plumbed_room.py
+++ b/heisenbridge/plumbed_room.py
@@ -58,20 +58,6 @@ class PlumbedRoom(ChannelRoom):
         super().init()
 
         cmd = CommandParser(
-            prog="MAXLINES", description="set maximum number of lines per message until truncation or pastebin"
-        )
-        cmd.add_argument("lines", type=int, nargs="?", help="Number of lines")
-        self.commands.register(cmd, self.cmd_maxlines)
-
-        cmd = CommandParser(prog="PASTEBIN", description="enable or disable automatic pastebin of long messages")
-        cmd.add_argument("--enable", dest="enabled", action="store_true", help="Enable pastebin")
-        cmd.add_argument(
-            "--disable", dest="enabled", action="store_false", help="Disable pastebin (messages will be truncated)"
-        )
-        cmd.set_defaults(enabled=None)
-        self.commands.register(cmd, self.cmd_pastebin)
-
-        cmd = CommandParser(
             prog="DISPLAYNAMES", description="enable or disable use of displaynames in relayed messages"
         )
         cmd.add_argument("--enable", dest="enabled", action="store_true", help="Enable displaynames")
@@ -163,12 +149,6 @@ class PlumbedRoom(ChannelRoom):
     def from_config(self, config: dict) -> None:
         super().from_config(config)
 
-        if "max_lines" in config:
-            self.max_lines = config["max_lines"]
-
-        if "use_pastebin" in config:
-            self.use_pastebin = config["use_pastebin"]
-
         if "use_displaynames" in config:
             self.use_displaynames = config["use_displaynames"]
 
@@ -190,8 +170,6 @@ class PlumbedRoom(ChannelRoom):
     def to_config(self) -> dict:
         return {
             **(super().to_config()),
-            "max_lines": self.max_lines,
-            "use_pastebin": self.use_pastebin,
             "use_displaynames": self.use_displaynames,
             "use_disambiguation": self.use_disambiguation,
             "use_zwsp": self.use_zwsp,
@@ -324,20 +302,6 @@ class PlumbedRoom(ChannelRoom):
             del ret[nick]
 
         return ret
-
-    async def cmd_maxlines(self, args) -> None:
-        if args.lines is not None:
-            self.max_lines = args.lines
-            await self.save()
-
-        self.send_notice(f"Max lines is {self.max_lines}")
-
-    async def cmd_pastebin(self, args) -> None:
-        if args.enabled is not None:
-            self.use_pastebin = args.enabled
-            await self.save()
-
-        self.send_notice(f"Pastebin is {'enabled' if self.use_pastebin else 'disabled'}")
 
     async def cmd_displaynames(self, args) -> None:
         if args.enabled is not None:

--- a/heisenbridge/plumbed_room.py
+++ b/heisenbridge/plumbed_room.py
@@ -135,6 +135,9 @@ class PlumbedRoom(ChannelRoom):
         # stamp global member sync setting at room creation time
         room.member_sync = network.serv.config["member_sync"]
 
+        room.max_lines = network.serv.config["max_lines"]
+        room.use_pastebin = network.serv.config["use_pastebin"]
+
         for user_id, member in joined.items():
             if member.displayname is not None:
                 room.displaynames[user_id] = member.displayname

--- a/heisenbridge/private_room.py
+++ b/heisenbridge/private_room.py
@@ -295,6 +295,10 @@ class PrivateRoom(Room):
         room.network = network
         room.network_id = network.id
         room.network_name = network.name
+
+        room.max_lines = network.serv.config["max_lines"]
+        room.use_pastebin = network.serv.config["use_pastebin"]
+
         asyncio.ensure_future(room._create_mx(name))
         return room
 

--- a/heisenbridge/private_room.py
+++ b/heisenbridge/private_room.py
@@ -445,7 +445,7 @@ class PrivateRoom(Room):
         # lazy update displayname if we detect a change
         if (
             not self.serv.is_user_cached(irc_user_id, event.source.nick)
-            and irc_user_id not in self.lazy_members
+            and irc_user_id not in (self.lazy_members or {})
             and irc_user_id in self.members
         ):
             asyncio.ensure_future(self.serv.ensure_irc_user_id(self.network.name, event.source.nick))


### PR DESCRIPTION
For one, it moves it from just plumbed channels to all all private channels.
Then it also adds a global default setting for it.

All the logic for doing the pasting is already there, so it was really just a matter of exposing the setting.

While testing this, I also ran into an error being spammed into my logs, of which I'm not sure if it's related, but the fix was trivial no matter what, so it's included here.

This should close issue #165 