### PR TITLE
Fix pre-commit CI

### DIFF
--- a/.github/workflows/precommit.yaml
+++ b/.github/workflows/precommit.yaml
@@ -11,4 +11,4 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
-    - uses: pre-commit/action@v2.0.2
+    - uses: pre-commit/action@v2.0.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,24 +1,24 @@
 exclude: 'README.md'
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.2.0
     hooks:
     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
     -   id: black
 -   repo: https://github.com/asottile/reorder_python_imports
-    rev: v2.4.0
+    rev: v3.1.0
     hooks:
     -   id: reorder-python-imports
-- repo: https://github.com/sirosen/check-jsonschema
-  rev: 0.3.0
-  hooks:
-    - id: check-github-workflows
+-   repo: https://github.com/sirosen/check-jsonschema
+    rev: 0.14.3
+    hooks:
+    -   id: check-github-workflows
 -   repo: https://github.com/pycqa/flake8
-    rev: 3.9.1
+    rev: 4.0.1
     hooks:
     -   id: flake8


### PR DESCRIPTION
A lot of versions were plain outdated and exploded horribly due to various package updates.
This just bumps all of them to their latest versions and makes things work again.