### PR TITLE
Hide invites in a hidden room

### DIFF
--- a/heisenbridge/appservice.py
+++ b/heisenbridge/appservice.py
@@ -1,3 +1,4 @@
+import logging
 from abc import ABC
 from abc import abstractmethod
 from typing import List
@@ -15,6 +16,7 @@ class AppService(ABC):
     user_id: str
     server_name: str
     config: dict
+    hidden_room: Room
 
     async def load(self):
         try:
@@ -25,29 +27,50 @@ class AppService(ABC):
     async def save(self):
         await self.az.intent.set_account_data("irc", self.config)
 
-    async def create_room(self, name: str, topic: str, invite: List[str]) -> str:
-        resp = await self.az.intent.api.request(
-            Method.POST,
-            Path.v3.createRoom,
-            {
-                "visibility": "private",
-                "name": name,
-                "topic": topic,
-                "invite": invite,
-                "is_direct": False,
-                "power_level_content_override": {
-                    "users_default": 0,
-                    "invite": 100,
-                    "kick": 100,
-                    "redact": 100,
-                    "ban": 100,
-                    "events": {
-                        "m.room.name": 0,
-                        "m.room.avatar": 0,  # these work as long as rooms are private
-                    },
+    async def create_room(self, name: str, topic: str, invite: List[str], restricted: str = None) -> str:
+        req = {
+            "visibility": "private",
+            "name": name,
+            "topic": topic,
+            "invite": invite,
+            "is_direct": False,
+            "power_level_content_override": {
+                "users_default": 0,
+                "invite": 100,
+                "kick": 100,
+                "redact": 100,
+                "ban": 100,
+                "events": {
+                    "m.room.name": 0,
+                    "m.room.avatar": 0,  # these work as long as rooms are private
                 },
             },
-        )
+        }
+
+        if restricted is not None:
+            resp = await self.az.intent.api.request(Method.GET, Path.v3.capabilities)
+            try:
+                def_ver = resp["capabilities"]["m.room_versions"]["default"]
+            except KeyError:
+                logging.debug("Unexpected capabilities reply")
+                def_ver = None
+
+            # If room version is in range of 1..8, request v9
+            if def_ver in [str(v) for v in range(1, 9)]:
+                req["room_version"] = "9"
+
+            req["initial_state"] = [
+                {
+                    "type": "m.room.join_rules",
+                    "state_key": "",
+                    "content": {
+                        "join_rule": "restricted",
+                        "allow": [{"type": "m.room_membership", "room_id": restricted}],
+                    },
+                }
+            ]
+
+        resp = await self.az.intent.api.request(Method.POST, Path.v3.createRoom, req)
 
         return resp["room_id"]
 

--- a/heisenbridge/channel_room.py
+++ b/heisenbridge/channel_room.py
@@ -140,6 +140,13 @@ class ChannelRoom(PrivateRoom):
         )
         self.commands.register(cmd, self.cmd_stop, ["STOP!", "STAHP", "STAHP!"])
 
+        cmd = CommandParser(
+            prog="UPGRADE",
+            description="Perform any potential bridge-side upgrades of the room",
+        )
+        cmd.add_argument("--undo", action="store_true", help="undo previously performed upgrade")
+        self.commands.register(cmd, self.cmd_upgrade)
+
         self.names_buffer = []
         self.bans_buffer = []
         self.on_channel = []
@@ -196,10 +203,14 @@ class ChannelRoom(PrivateRoom):
         if visible_name.startswith("!"):
             visible_name = "!" + visible_name[6:]
 
+        if self.serv.hidden_room:
+            self.hidden_room_id = self.serv.hidden_room.id
+
         self.id = await self.network.serv.create_room(
             f"{visible_name} ({self.network.name})",
             "",
             [self.network.user_id],
+            self.hidden_room_id,
         )
         self.serv.register_room(self)
         await self.save()

--- a/heisenbridge/hidden_room.py
+++ b/heisenbridge/hidden_room.py
@@ -1,0 +1,37 @@
+import logging
+
+from heisenbridge.appservice import AppService
+from heisenbridge.room import Room
+
+
+class HiddenRoom(Room):
+    @staticmethod
+    async def create(serv: AppService) -> "HiddenRoom":
+        logging.debug("HiddenRoom.create(serv)")
+        room_id = await serv.create_room("heisenbridge-hidden-room", "Invite-Sink for Heisenbridge", [])
+        room = HiddenRoom(
+            room_id,
+            None,
+            serv,
+            [serv.user_id],
+            [],
+        )
+        await room.save()
+        serv.register_room(room)
+        return room
+
+    def is_valid(self) -> bool:
+        # Hidden Room usage has been explicitly disabled by user
+        if not self.serv.config.get("use_hidden_room", True):
+            return False
+
+        # Server already has a (different) hidden room
+        if self.serv.hidden_room and self.serv.hidden_room is not self:
+            return False
+
+        return True
+
+    async def post_init(self) -> None:
+        # Those can be huge lists, but are entirely unused. Free up some memory.
+        self.members = []
+        self.displaynames = {}

--- a/heisenbridge/room.py
+++ b/heisenbridge/room.py
@@ -27,6 +27,7 @@ class Room(ABC):
     serv: AppService
     members: List[str]
     lazy_members: Optional[Dict[str, str]]
+    hidden_room_id: Optional[str]
     bans: List[str]
     displaynames: Dict[str, str]
     parser: IRCMatrixParser
@@ -41,6 +42,7 @@ class Room(ABC):
         self.members = list(members)
         self.bans = list(bans) if bans else []
         self.lazy_members = None
+        self.hidden_room_id = None
         self.displaynames = {}
         self.last_messages = defaultdict(str)
         self.parser = IRCMatrixParser(self.displaynames)
@@ -148,6 +150,9 @@ class Room(ABC):
                 del self.displaynames[event.state_key]
 
     async def _join(self, user_id, nick=None):
+        if self.hidden_room_id:
+            await self.az.intent.user(user_id).ensure_joined(self.hidden_room_id)
+
         await self.az.intent.user(user_id).ensure_joined(self.id, ignore_cache=True)
 
         self.members.append(user_id)


### PR DESCRIPTION
Makes use of version 9 rooms ability to be restricted to allow users who are members of another rooms.
Joins all puppeted users into the hidden room first, if one is set for the channel.
Avoids invite spam in the actual rooms.

Migration of existing rooms is possible via room level command, if they are first migrated to version 9 via external means (most Clients can do that with a simple command).