### PR TITLE
Fix use of deprecated asyncio functions

### DIFF
--- a/heisenbridge/event_queue.py
+++ b/heisenbridge/event_queue.py
@@ -10,7 +10,7 @@ class EventQueue:
     def __init__(self, callback):
         self._callback = callback
         self._events = []
-        self._loop = asyncio.get_event_loop()
+        self._loop = asyncio.get_running_loop()
         self._timer = None
         self._start = 0
         self._chain = asyncio.Queue()

--- a/heisenbridge/identd.py
+++ b/heisenbridge/identd.py
@@ -67,6 +67,6 @@ class Identd:
         if socket.has_ipv6:
             sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
             sock.bind(("::", port))
-            self.server = await asyncio.start_server(self.handle, sock=sock, loop=asyncio.get_event_loop(), limit=128)
+            self.server = await asyncio.start_server(self.handle, sock=sock, limit=128)
         else:
             self.server = await asyncio.start_server(self.handle, "0.0.0.0", port, limit=128)

--- a/heisenbridge/irc.py
+++ b/heisenbridge/irc.py
@@ -181,7 +181,7 @@ class HeisenConnection(AioConnection):
         super().close()
 
     async def _run(self):
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         last = loop.time()
         penalty = 0
 

--- a/heisenbridge/network_room.py
+++ b/heisenbridge/network_room.py
@@ -1087,7 +1087,7 @@ class NetworkRoom(Room):
 
     async def cmd_status(self, args) -> None:
         if self.connected_at > 0:
-            conntime = asyncio.get_event_loop().time() - self.connected_at
+            conntime = asyncio.get_running_loop().time() - self.connected_at
             conntime = str(datetime.timedelta(seconds=int(conntime)))
             self.send_notice(f"Connected for {conntime}")
 
@@ -1290,7 +1290,7 @@ class NetworkRoom(Room):
 
                     self.send_notice(f"SASL mechanism set to '{sasl_mechanism if sasl_mechanism else 'none'}'")
 
-                reactor = HeisenReactor(loop=asyncio.get_event_loop())
+                reactor = HeisenReactor(loop=asyncio.get_running_loop())
                 irc_server = reactor.server()
                 irc_server.buffer_class = buffer.LenientDecodingLineBuffer
                 factory = irc.connection.AioFactory(ssl=ssl_ctx, sock=sock, server_hostname=server_hostname)
@@ -1396,7 +1396,7 @@ class NetworkRoom(Room):
                     return
 
                 self.disconnect = False
-                self.connected_at = asyncio.get_event_loop().time()
+                self.connected_at = asyncio.get_running_loop().time()
 
                 # request CAPs
                 caps_req = list(self.caps)
@@ -1535,7 +1535,7 @@ class NetworkRoom(Room):
             self.conn = None
 
         # if we were connected for a while, consider the server working
-        if self.connected_at > 0 and asyncio.get_event_loop().time() - self.connected_at > 300:
+        if self.connected_at > 0 and asyncio.get_running_loop().time() - self.connected_at > 300:
             self.backoff = 0
             self.next_server = 0
             self.connected_at = 0
@@ -1852,7 +1852,7 @@ class NetworkRoom(Room):
 
             self.conn.nick(self.get_nick())
 
-        self.keepnick_task = asyncio.get_event_loop().call_later(300, try_keepnick)
+        self.keepnick_task = asyncio.get_running_loop().call_later(300, try_keepnick)
 
     def on_invite(self, conn, event) -> None:
         rejoin = ""


### PR DESCRIPTION
get_event_loop() throws a deprecation warning on Python 3.10, and will lose its ability to implicitly create an event loop in future versions.
Since Python 3.7, using asyncio.run() is preferred. And since heisenbridge seems to demand >=3.8, we can just safely switch to the new functions.

Likewise, asyncio.start_server() has losts its loop parameter in Python 3.10, so removing usage of that as well. It should always be able to deduce the current loop on its own.