### PR TITLE
Autojoin Twitch users when they speak

### DIFF
--- a/heisenbridge/private_room.py
+++ b/heisenbridge/private_room.py
@@ -595,6 +595,13 @@ class PrivateRoom(Room):
                 # add self to lazy members list so it'll echo
                 self.lazy_members[source_irc_user_id] = event.source.nick
 
+        if (
+            'twitch.tv/membership' in self.network.caps
+            and irc_user_id not in self.members
+            and irc_user_id not in self.lazy_members
+        ):
+            self.lazy_members[irc_user_id] = event.source.nick
+
         self.send_message(
             plain,
             irc_user_id,

--- a/heisenbridge/private_room.py
+++ b/heisenbridge/private_room.py
@@ -596,7 +596,7 @@ class PrivateRoom(Room):
                 self.lazy_members[source_irc_user_id] = event.source.nick
 
         if (
-            'twitch.tv/membership' in self.network.caps
+            "twitch.tv/membership" in self.network.caps
             and irc_user_id not in self.members
             and irc_user_id not in self.lazy_members
         ):


### PR DESCRIPTION
This makes users on twitch autojoin before they speak if they have not yet joined, because twitch's server is very wonky about sending timely JOINs.

Fixes #208.