### PR TITLE
Double-check room member removal

### DIFF
--- a/heisenbridge/room.py
+++ b/heisenbridge/room.py
@@ -180,7 +180,8 @@ class Room(ABC):
                             )
                         else:
                             await self.az.intent.user(event["user_id"]).leave_room(self.id)
-                        self.members.remove(event["user_id"])
+                        if event["user_id"] in self.members:
+                            self.members.remove(event["user_id"])
                         if event["user_id"] in self.displaynames:
                             del self.displaynames[event["user_id"]]
                 elif event["type"] == "_rename":


### PR DESCRIPTION
There seems to be a situation where the command right before this already clears the user from the members list, which in turn causes this line to throw a ValueError, complaining about the user_id not being in the members list.