### PR TITLE
Make Docker image ~9x smaller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,17 @@
 FROM docker.io/alpine:3.17.0
 
-RUN apk add --no-cache python3 py3-setuptools py3-pip py3-ruamel.yaml.clib
+# install runtime dependencies
+RUN apk add --no-cache python3 py3-ruamel.yaml.clib
 
 WORKDIR /opt/heisenbridge
 COPY . .
 
 # install deps and run a sanity check
-RUN python setup.py gen_version && \
+RUN apk add --no-cache --virtual build-dependencies py3-setuptools py3-pip && \
+    python setup.py gen_version && \
     rm -rf .git && \
     pip install -e . && \
+    apk del build-dependencies && \
     python -m heisenbridge  -h
 
 # identd also needs to be enabled with --identd in CMD

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM python:3.9 as build
+FROM docker.io/alpine:3.17.0
+
+RUN apk add --no-cache python3 py3-setuptools py3-pip py3-ruamel.yaml.clib
 
 WORKDIR /opt/heisenbridge
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,10 @@ WORKDIR /opt/heisenbridge
 COPY . .
 
 # install deps and run a sanity check
-RUN apk add --no-cache --virtual build-dependencies py3-setuptools py3-pip && \
+#
+# `python3-dev gcc musl-dev` are installed because building `multidict`
+# on armv7l fails otherwise. amd64 and aarch64 don't need this.
+RUN apk add --no-cache --virtual build-dependencies py3-setuptools py3-pip python3-dev gcc musl-dev && \
     python setup.py gen_version && \
     rm -rf .git && \
     pip install -e . && \


### PR DESCRIPTION
Fixes https://github.com/hifi/heisenbridge/issues/244

I've confirmed that this builds successfully on `amd64`, `armv7l` and `aarch64` with the following image sizes before and after:

- `amd64`: (1 GB -> 142 MB) - 7x improvement
- `armv7l` (731 MB -> 80.3 MB) - 9x improvement
- `aarch64`: (895 MB -> 79.2 MB) - 11x improvement

---

The Docker image now builds from a well-known statically defined base (`alpine:3.17.0`), so compared to using something like `python:3.9`, there should be no surprises where it fails to build in the future.. or yields a different build because the underlying base image changed.