### PR TITLE
Accept elliptic curve keys in the CERTFP command

### DIFF
--- a/heisenbridge/network_room.py
+++ b/heisenbridge/network_room.py
@@ -971,7 +971,7 @@ class NetworkRoom(Room):
                 self.send_notice("Certificate section is missing.")
                 return
 
-            if "-----BEGIN PRIVATE KEY----" not in args._tail:
+            if "PRIVATE KEY----" not in args._tail:
                 self.send_notice("Private key section is missing.")
                 return
 


### PR DESCRIPTION
Or more correctly stop preventing them from being used. For an EC key the PEM contains `-----BEGIN EC PRIVATE KEY-----` instead of `-----BEGIN PRIVATE KEY----`, which wasn't matched by this sanity check. If one wanted to be more specific the `-----BEGIN EC PARAMETERS-----` section could also be required if EC PRIVATE KEY exists and PRIVATE KEY doesn't, but as this is a trivial sanity check that probably isn't important.