### PR TITLE
Use urljoin in mxc_to_url to avoid issues with extra slashes

### DIFF
--- a/heisenbridge/__main__.py
+++ b/heisenbridge/__main__.py
@@ -340,7 +340,10 @@ class BridgeAppService(AppService):
         else:
             filename = "/" + urllib.parse.quote(filename)
 
-        return "{}/_matrix/media/r0/download/{}{}{}".format(self.endpoint, mxc.netloc, mxc.path, filename)
+        return urllib.parse.urljoin(
+            self.endpoint,
+            "/_matrix/media/r0/download/{}{}{}".format(mxc.netloc, mxc.path, filename),
+        )
 
     async def reset(self, config_file, homeserver_url):
         with open(config_file) as f:


### PR DESCRIPTION
Whether or not the URL returned from detect_public_endpoint includes a trailing slash varies depending on external factors (what the homeserver operator put in the well-known file, whether the user included a trailing slash on the command line). Use urljoin to avoid an extra slash regardless (the media URL path should not start with `//_matrix/media/`.