### PR TITLE
implement user presence

### DIFF
--- a/heisenbridge/__main__.py
+++ b/heisenbridge/__main__.py
@@ -28,6 +28,7 @@ from mautrix.errors import MUserInUse
 from mautrix.types import EventType
 from mautrix.types import JoinRule
 from mautrix.types import Membership
+from mautrix.types import PresenceState
 from mautrix.util.bridge_state import BridgeState
 from mautrix.util.bridge_state import BridgeStateEvent
 from mautrix.util.config import yaml
@@ -191,6 +192,19 @@ class BridgeAppService(AppService):
             ret += ":" + self.server_name
 
         return ret
+
+    def set_user_state(self, user_id, away, status=None):
+        if user_id not in self._users:
+            return
+
+        presence = PresenceState.ONLINE
+        if away:
+            presence = PresenceState.UNAVAILABLE
+
+        async def later():
+            await self.az.intent.user(user_id).set_presence(presence=presence, status=status)
+
+        asyncio.ensure_future(later())
 
     async def cache_user(self, user_id, displayname):
         # start by caching that the user_id exists without a displayname

--- a/heisenbridge/channel_room.py
+++ b/heisenbridge/channel_room.py
@@ -478,6 +478,9 @@ class ChannelRoom(PrivateRoom):
 
                 asyncio.ensure_future(autocmd(self))
 
+            # Run a WHO on the channel to get initial away status
+            self.network.conn.who(target=event.target)
+
             return
 
         # ensure, append, invite and join


### PR DESCRIPTION
When joining a channel a WHO is executed to gather initial AWAY status for all users in the channel. After that user presence is updated when further AWAY messages are received.

closes #41 