### PR TITLE
Create private chats with the is_direct flag

### DIFF
--- a/heisenbridge/appservice.py
+++ b/heisenbridge/appservice.py
@@ -27,13 +27,13 @@ class AppService(ABC):
     async def save(self):
         await self.az.intent.set_account_data("irc", self.config)
 
-    async def create_room(self, name: str, topic: str, invite: List[str], restricted: str = None) -> str:
+    async def create_room(self, name: str, topic: str, invite: List[str], restricted: str = None, as_user: str = None, is_direct: bool = False) -> str:
         req = {
             "visibility": "private",
             "name": name,
             "topic": topic,
             "invite": invite,
-            "is_direct": False,
+            "is_direct": is_direct,
             "power_level_content_override": {
                 "users_default": 0,
                 "invite": 100,
@@ -70,7 +70,8 @@ class AppService(ABC):
                 }
             ]
 
-        resp = await self.az.intent.api.request(Method.POST, Path.v3.createRoom, req)
+        intent = self.az.intent.user(as_user) if as_user else self.az.intent
+        resp = await intent.api.request(Method.POST, Path.v3.createRoom, req)
 
         return resp["room_id"]
 

--- a/heisenbridge/private_room.py
+++ b/heisenbridge/private_room.py
@@ -19,6 +19,7 @@ from mautrix.types.event.state import JoinRestriction
 from mautrix.types.event.state import JoinRestrictionType
 from mautrix.types.event.state import JoinRule
 from mautrix.types.event.state import JoinRulesStateEventContent
+from mautrix.types.event.state import PowerLevelStateEventContent
 from mautrix.types.event.type import EventType
 
 from heisenbridge.command_parse import CommandManager
@@ -468,10 +469,14 @@ class PrivateRoom(Room):
             self.id = await self.network.serv.create_room(
                 "{} ({})".format(displayname, self.network.name),
                 "Private chat with {} on {}".format(displayname, self.network.name),
-                [self.network.user_id, irc_user_id],
+                [self.network.user_id, self.network.serv.user_id],
+                as_user=irc_user_id, is_direct=True,
             )
             self.serv.register_room(self)
-            await self.az.intent.user(irc_user_id).ensure_joined(self.id)
+            await self.az.intent.ensure_joined(self.id)
+            power_levels = PowerLevelStateEventContent()
+            power_levels.set_user_level(self.network.serv.user_id, 100)
+            await self.az.intent.user(irc_user_id).set_power_levels(self.id, power_levels)
             await self.save()
             # start event queue now that we have an id
             self._queue.start()


### PR DESCRIPTION
This changes the creation logic for private rooms to use the `is_direct` flag, so the room will be correctly recognized as a direct chat. To prevent the created room from being recognized as a private chat with the bridge user, we create the room as the irc user and then invite the real user and bridge user into the room and change the power levels to give power to the bridge user and take it from the irc user. This should leave the room in the same state after creation as before the change, but the initial invite to the real user is sent from the irc user and not the bridge user. This should cause clients to correctly recognize the irc user as the direct chat partner instead of the bridge user. This works correctly on element web, though I have not tested the behavior in other clients.