### PR TITLE
Support specifying TLS cipher list per server

### DIFF
--- a/heisenbridge/control_room.py
+++ b/heisenbridge/control_room.py
@@ -112,6 +112,11 @@ class ControlRoom(Room):
                 help="ignore TLS verification errors (hostname, self-signed, expired)",
                 default=False,
             )
+            cmd.add_argument(
+                "--tls-ciphers",
+                help="set TLS cipher string (in OpenSSL cipher list format)",
+                default=None,
+            )
             cmd.add_argument("--proxy", help="use a SOCKS proxy (socks5://...)", default=None)
             self.commands.register(cmd, self.cmd_addserver)
 
@@ -371,6 +376,7 @@ class ControlRoom(Room):
                 "port": args.port,
                 "tls": args.tls,
                 "tls_insecure": args.tls_insecure,
+                "tls_ciphers": args.tls_ciphers,
                 "proxy": args.proxy,
             }
         )

--- a/heisenbridge/network_room.py
+++ b/heisenbridge/network_room.py
@@ -1266,6 +1266,10 @@ class NetworkRoom(Room):
 
                         cert_file.close()
 
+                    if "tls_ciphers" in server and server["tls_ciphers"]:
+                        with_tls += " using custom cipher list"
+                        ssl_ctx.set_ciphers(server["tls_ciphers"])
+
                     server_hostname = server["address"]
 
                 proxy = None


### PR DESCRIPTION
Some servers with weird TLS configurations don't accept any of the ciphers
in the default Python ssl module cipher list. To connect to such a server,
it is necessary to specify a custom cipher list, so add an option to the
ADDSERVER command to specify a per-server custom cipher list and pass it
into the SSL context object if set.