### PR TITLE
Add ability to configure the media path for reverse proxies

### DIFF
--- a/heisenbridge/control_room.py
+++ b/heisenbridge/control_room.py
@@ -201,6 +201,11 @@ class ControlRoom(Room):
             cmd.add_argument("--remove", help="remove URL override (will retry auto-detection)", action="store_true")
             self.commands.register(cmd, self.cmd_media_url)
 
+            cmd = CommandParser(prog="MEDIAPATH", description="configure media path for links")
+            cmd.add_argument("path", nargs="?", help="new path override")
+            cmd.add_argument("--remove", help="remove path override", action="store_true")
+            self.commands.register(cmd, self.cmd_media_path)
+
             cmd = CommandParser(prog="VERSION", description="show bridge version")
             self.commands.register(cmd, self.cmd_version)
 
@@ -567,6 +572,19 @@ class ControlRoom(Room):
 
         self.send_notice(f"Media URL override is set to {self.serv.config['media_url']}")
         self.send_notice(f"Current active media URL: {self.serv.endpoint}")
+
+    async def cmd_media_path(self, args):
+        if args.remove:
+            self.serv.config["media_path"] = None
+            await self.serv.save()
+            self.serv.media_path = self.serv.DEFAULT_MEDIA_PATH
+        elif args.path:
+            self.serv.config["media_path"] = args.path
+            await self.serv.save()
+            self.serv.media_path = args.path
+
+        self.send_notice(f"Media Path override is set to {self.serv.config['media_path']}")
+        self.send_notice(f"Current active media path: {self.serv.media_path}")
 
     async def cmd_maxlines(self, args):
         if args.lines is not None:


### PR DESCRIPTION
Resolves #266.

Includes #238.

![img-2023-09-25-194456](https://github.com/hifi/heisenbridge/assets/2362091/0114bbdc-21a2-456d-996b-6a883d5ef266)

![img-2023-09-25-194514](https://github.com/hifi/heisenbridge/assets/2362091/e3637413-e17c-44b6-af9d-918d8d0c4067)

Nginx config used in the example above:
```nginx
upstream synapse {
  server 127.0.0.1:8008;
  keepalive 20;
}

map $upstream_http_content_type $matrix_media {
    "text/plain"            "inline";
    "text/css"              "inline";

    "application/pdf"       "inline";

    "image/gif"             "inline";
    "image/jpeg"            "inline";
    "image/avif"            "inline";
    "image/png"             "inline";
    "image/tiff"            "inline";
    "image/vnd.wap.wbmp"    "inline";
    "image/webp"            "inline";
    "image/x-icon"          "inline";
    "image/x-jng"           "inline";
    "image/x-ms-bmp"        "inline";

    "audio/basic"           "inline";
    "audio/midi"            "inline";
    "audio/mpeg"            "inline";
    "audio/ogg"             "inline";
    "audio/x-m4a"           "inline";
    "audio/x-realaudio"     "inline";

    "video/3gpp"            "inline";
    "video/mp2t"            "inline";
    "video/mp4"             "inline";
    "video/mpeg"            "inline";
    "video/quicktime"       "inline";
    "video/webm"            "inline";
    "video/x-flv"           "inline";
    "video/x-m4v"           "inline";
    "video/x-matroska"      "inline";
    "video/x-mng"           "inline";
    "video/x-ms-asf"        "inline";
    "video/x-ms-wmv"        "inline";
    "video/x-msvideo"       "inline";

    default                 "attachement";
}


server {
  listen       *:443 ssl http2;
  listen       [::]:443 ssl http2 ;

  server_name  irc.hash.works;

  ssl_certificate           /etc/letsencrypt/live/irc.hash.works/fullchain.pem;
  ssl_certificate_key       /etc/letsencrypt/live/irc.hash.works/privkey.pem;

  location / {
    proxy_pass            http://synapse/_matrix/media/v3/download/kromlinger.eu/;
    proxy_http_version    1.1;
    proxy_set_header      Host $http_host;
    proxy_set_header      X-Forwarded-For $proxy_add_x_forwarded_for;
    proxy_set_header      X-Forwarded-Proto $scheme;

    proxy_hide_header Content-Disposition;
    add_header Content-Disposition $matrix_media;
  }
}
```
