### PR TITLE
Send multiple JOIN commands if 512 bytes message length is violated

### DIFF
--- a/heisenbridge/irc.py
+++ b/heisenbridge/irc.py
@@ -185,6 +185,13 @@ class HeisenConnection(AioConnection):
         last = loop.time()
         penalty = 0
 
+        async def send_and_sleep(self, message):
+            super().send_raw(message)
+            # sleep is based on message length
+            sleep_time = max(len(message.encode()) / 512 * 6, 1.5)
+            if penalty > 5 or sleep_time > 1.5:
+                await asyncio.sleep(sleep_time)
+
         while True:
             try:
                 (priority, string, tag) = await self._queue.get()
@@ -199,13 +206,15 @@ class HeisenConnection(AioConnection):
                     if penalty < 0:
                         penalty = 0
 
-                super().send_raw(string)
+                s_len = len(string)
+                if s_len > 510 and string.split(" ")[0].lower() == "join":
+                    n_splits = int(s_len / 512) + (s_len % 512 > 0)
+                    channels = "".join(string.split(" ")[1:]).split(",")
 
-                # sleep is based on message length
-                sleep_time = max(len(string.encode()) / 512 * 6, 1.5)
-
-                if penalty > 5 or sleep_time > 1.5:
-                    await asyncio.sleep(sleep_time)
+                    for i in range(n_splits):
+                        await send_and_sleep(self, "JOIN " + ",".join(channels[i::n_splits]))
+                else:
+                    await send_and_sleep(self, string)
 
                 # this needs to be reset if we slept
                 last = loop.time()


### PR DESCRIPTION
As messages are limited to 512 bytes including CR/LF, the JOIN command fails if the amount of channels intended to be joined is too large.

This commit allows joining a larger number of rooms by splitting the channels to be joined among multiple JOIN commands instead of running only one join commands which violates the message length.