### PR TITLE
Add media-src 'self'; to CSP

### DIFF
--- a/heisenbridge/__main__.py
+++ b/heisenbridge/__main__.py
@@ -354,7 +354,7 @@ class BridgeAppService(AppService):
         headers: dict[str, str] = {"Authorization": f"Bearer {self.az.as_token}"}
         resp_headers = {
             "Content-Security-Policy": (
-                "sandbox; default-src 'none'; script-src 'none'; style-src 'none'; object-src 'none';"
+                "sandbox; default-src 'none'; script-src 'none'; style-src 'none'; media-src 'self'; object-src 'none';"
             ),
             "Access-Control-Allow-Origin": "*",
             "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",


### PR DESCRIPTION
For various browser bug reasons, some medias doesn't load in some browsers without `content-security-policy` header having `media-src 'self';` in it. This adds it.

Signed-off-by: Sami Olmari <sami@olmari.fi>
Tested-off-by: Sami Olmari <sami@olmari.fi>