### PR TITLE
Fix outdated link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ If for whatever reason you run Heisenbridge over the internet and require HTTPS 
 
 For [Synapse](https://github.com/matrix-org/synapse) see their [installation instructions](https://github.com/matrix-org/synapse/blob/develop/docs/application_services.md) for appservices.
 
-For [Conduit](https://gitlab.com/famedly/conduit) see their [installation instructions](https://gitlab.com/famedly/conduit/-/blob/next/APPSERVICES.md) for appservices.
+For [Conduit](https://gitlab.com/famedly/conduit) see their [installation instructions](https://docs.conduit.rs/appservices.html) for appservices.
 
 Install
 -------


### PR DESCRIPTION
The link pointed to a file that doesn't exist anymore on the `next` branch. Instead it is now in the MdBook since merge request [#604](https://gitlab.com/famedly/conduit/-/merge_requests/604/diffs#1a3fe7f129f28f2f34add8afebac18875a34dba6).