### PR TITLE
Switch pip → pipx in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ PyPI
 GitHub releases are automatically published to [PyPI](https://pypi.org/project/heisenbridge/):
 
 ```sh
-pip install heisenbridge
+pipx install heisenbridge
 ```
 
 Docker


### PR DESCRIPTION
On a macOS system, 
```
➜ pip3 install heisenbridge
error: externally-managed-environment

× This environment is externally managed
╰─> If you wish to install a Python application that isn't in Homebrew,
    it may be easiest to use 'pipx install xyz', which will manage a
    virtual environment for you. [...]

    You may restore the old behavior of pip by passing
    the '--break-system-packages' flag to pip[...]

```

Thus these instructions are patently incorrect for macOS, and possibly for other platforms as well.