### PR TITLE
Fix kicking IRC users on plumbed rooms when they change their nick

### DIFF
--- a/heisenbridge/network_room.py
+++ b/heisenbridge/network_room.py
@@ -1849,6 +1849,10 @@ class NetworkRoom(Room):
         # leave and join channels
         for room in self.rooms.values():
             if type(room) is ChannelRoom or type(room) is PlumbedRoom:
+                # Update the channel's IRC-side user list so that we don't try to bridge the puppet being kicked to
+                # an actual IRC kick
+                room.channel_leave(event.source.nick)
+                room.channel_join(event.target)
                 room.rename(event.source.nick, event.target)
 
     def on_nicknameinuse(self, conn, event) -> None:


### PR DESCRIPTION
Heisenbridge translates IRC nick changes to Matrix by kicking the puppet with the old nick and joining a new one with the new nick. However, the IRC user list is not updated before kicking the old puppet; therefore the on_mx_leave handler ends up kicking the IRC user's old nick. Finally, some IRCds allow kicks to track nick changes, so the end result is that the person changing nicks gets kicked from IRC.

on_mx_leave already checks is_on_channel, so the quick fix is to update the on_channel list for each channel to reflect nick changes.

Fixes #279