### PR TITLE
Make _detach_hidden_room_internal errors non-fatal

### DIFF
--- a/heisenbridge/private_room.py
+++ b/heisenbridge/private_room.py
@@ -14,7 +14,7 @@ from urllib.parse import urlparse
 
 from mautrix.api import Method
 from mautrix.api import SynapseAdminPath
-from mautrix.errors import MatrixStandardRequestError
+from mautrix.errors import MatrixError, MatrixStandardRequestError
 from mautrix.types import MessageEvent
 from mautrix.types import TextMessageEventContent
 from mautrix.types.event.state import JoinRestriction
@@ -955,11 +955,18 @@ class PrivateRoom(Room):
         self.hidden_room_id = self.serv.hidden_room.id
 
     async def _detach_hidden_room_internal(self) -> None:
-        await self.az.intent.send_state_event(
-            self.id,
-            EventType.ROOM_JOIN_RULES,
-            content=JoinRulesStateEventContent(join_rule=JoinRule.INVITE),
-        )
+        try:
+            await self.az.intent.send_state_event(
+                self.id,
+                EventType.ROOM_JOIN_RULES,
+                content=JoinRulesStateEventContent(join_rule=JoinRule.INVITE),
+            )
+        except MatrixError:
+            logging.warning(
+                f"Failed to detach hidden room for {self.id}. If this room is restricted to Space members and you are "
+                "not using the hidden room setting, you may ignore this error.",
+                exc_info=True,
+            )
         self.hidden_room_id = None
 
     async def _attach_hidden_room(self) -> None:


### PR DESCRIPTION
When Heisenbridge starts up, it reads join rules for the room and always treats the first allowed space as the hidden room ID. This assumption is probably wrong, but the effect is that it conflicts with rooms that were separately set to allow certain Space members to join.

In such scenarios, Heisenbridge attempts to deconfigure the allowed spaces on startup, and preventing it from doing so by lowering its permissions result in an IntentError. Until this is fixed properly, let's make these errors non-fatal so the bridge can still run with reduced permissions.

This should fix #285, which more or less has the same traceback