### PR TITLE
Add URL link previews and inline media embedding

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Features
 * CTCP support
 * SOCKS proxy configuration per server
 * bridge managed spaces to organize your channels and PMs within a network
+* URL link previews (MSC4095) and inline media embedding for links in IRC messages
 
 Comparison
 ----------

--- a/heisenbridge/__main__.py
+++ b/heisenbridge/__main__.py
@@ -504,7 +504,44 @@ class BridgeAppService(AppService):
 
         return use_hidden_room
 
-    async def run(self, listen_address, listen_port, homeserver_url, owner, safe_mode, media_proxy):
+    def init_url_preview_fetcher(self):
+        """(Re)create the URL preview fetcher from current config."""
+        old = getattr(self, "url_preview_fetcher", None)
+        if old is not None:
+            asyncio.ensure_future(old.close())
+
+        if not self.config.get("url_previews"):
+            self.url_preview_fetcher = None
+            logging.info("URL previews disabled")
+            return
+
+        from heisenbridge.url_preview import URLPreviewFetcher
+
+        self.url_preview_fetcher = URLPreviewFetcher(
+            self.az.intent,
+            embed_media=self.config.get("url_preview_embed_media", True),
+            allowed_domains=self.config.get("url_preview_domains") or [],
+            fetch_timeout=self._url_preview_timeout,
+        )
+        domains = self.config.get("url_preview_domains") or []
+        logging.info(
+            "URL previews enabled (embed_media=%s, domains=%s)",
+            self.config.get("url_preview_embed_media", True),
+            ", ".join(domains) if domains else "all",
+        )
+
+    async def run(
+        self,
+        listen_address,
+        listen_port,
+        homeserver_url,
+        owner,
+        safe_mode,
+        media_proxy,
+        url_previews=True,
+        url_preview_timeout=6.0,
+    ):
+        self._url_preview_timeout = url_preview_timeout
         if "sender_localpart" not in self.registration:
             print("Missing sender_localpart from registration file.")
             sys.exit(1)
@@ -641,6 +678,10 @@ class BridgeAppService(AppService):
             "media_path": None,
             "media_key": None,
             "namespace": self.puppet_prefix,
+            # URL link previews / inline media embedding (issue #209)
+            "url_previews": url_previews,
+            "url_preview_embed_media": True,
+            "url_preview_domains": [],
         }
         logging.debug(f"Default config: {self.config}")
         self.synapse_admin = False
@@ -716,6 +757,12 @@ class BridgeAppService(AppService):
         if owner is not None and self.config["owner"] != owner:
             logging.info(f"Overriding loaded owner with '{owner}'")
             self.config["owner"] = owner
+
+        # command line --no-url-previews always wins over stored config
+        if not url_previews:
+            self.config["url_previews"] = False
+
+        self.init_url_preview_fetcher()
 
         # always ensure our merged and migrated configuration is up-to-date
         await self.save()
@@ -933,6 +980,18 @@ async def async_main():
         default=None,
     )
     parser.add_argument(
+        "--url-previews",
+        action=argparse.BooleanOptionalAction,
+        help="generate MSC4095 link preview cards and inline media for URLs in IRC messages",
+        default=True,
+    )
+    parser.add_argument(
+        "--url-preview-timeout",
+        type=float,
+        help="HTTP timeout in seconds for URL preview fetches",
+        default=6.0,
+    )
+    parser.add_argument(
         "homeserver",
         nargs="?",
         help="URL of Matrix homeserver",
@@ -1030,7 +1089,16 @@ async def async_main():
             except Exception:
                 pass
 
-        await service.run(listen_address, listen_port, args.homeserver, args.owner, args.safe_mode, args.media_proxy)
+        await service.run(
+            listen_address,
+            listen_port,
+            args.homeserver,
+            args.owner,
+            args.safe_mode,
+            args.media_proxy,
+            url_previews=args.url_previews,
+            url_preview_timeout=args.url_preview_timeout,
+        )
 
 
 def main():

--- a/heisenbridge/__main__.py
+++ b/heisenbridge/__main__.py
@@ -515,6 +515,7 @@ class BridgeAppService(AppService):
             logging.info("URL previews disabled")
             return
 
+        from heisenbridge.url_preview import DEFAULT_USER_AGENT
         from heisenbridge.url_preview import URLPreviewFetcher
 
         self.url_preview_fetcher = URLPreviewFetcher(
@@ -522,6 +523,7 @@ class BridgeAppService(AppService):
             embed_media=self.config.get("url_preview_embed_media", True),
             allowed_domains=self.config.get("url_preview_domains") or [],
             fetch_timeout=self._url_preview_timeout,
+            user_agent=self.config.get("url_preview_user_agent") or DEFAULT_USER_AGENT,
         )
         domains = self.config.get("url_preview_domains") or []
         logging.info(
@@ -682,6 +684,7 @@ class BridgeAppService(AppService):
             "url_previews": url_previews,
             "url_preview_embed_media": True,
             "url_preview_domains": [],
+            "url_preview_user_agent": None,
         }
         logging.debug(f"Default config: {self.config}")
         self.synapse_admin = False

--- a/heisenbridge/control_room.py
+++ b/heisenbridge/control_room.py
@@ -216,6 +216,27 @@ class ControlRoom(Room):
             cmd.add_argument("--remove", help="remove path override", action="store_true")
             self.commands.register(cmd, self.cmd_media_path)
 
+            cmd = CommandParser(
+                prog="URLPREVIEW",
+                description="configure URL link previews and inline media embedding",
+                epilog=(
+                    "Generates MSC4095 preview cards for web links and, when media embedding is on,"
+                    " inline image/video/audio for direct media URLs. With no arguments, shows status."
+                ),
+            )
+            cmd.add_argument("--enable", dest="enabled", action="store_true", help="Enable URL previews")
+            cmd.add_argument("--disable", dest="enabled", action="store_false", help="Disable URL previews")
+            cmd.set_defaults(enabled=None)
+            cmd.add_argument("--embed-media", dest="embed", action="store_true", help="Embed direct media inline")
+            cmd.add_argument(
+                "--no-embed-media", dest="embed", action="store_false", help="Show direct media as a card only"
+            )
+            cmd.set_defaults(embed=None)
+            cmd.add_argument("--allow-domain", help="restrict previews to this domain (repeatable)", action="append")
+            cmd.add_argument("--remove-domain", help="remove a domain from the allowlist", action="append")
+            cmd.add_argument("--clear-domains", action="store_true", help="clear the domain allowlist (allow all)")
+            self.commands.register(cmd, self.cmd_urlpreview)
+
             cmd = CommandParser(prog="VERSION", description="show bridge version")
             self.commands.register(cmd, self.cmd_version)
 
@@ -617,6 +638,45 @@ class ControlRoom(Room):
             await self.serv.save()
 
         self.send_notice(f"Reacts are {'enabled' if self.serv.config['use_reacts'] else 'disabled'} by default")
+
+    async def cmd_urlpreview(self, args):
+        changed = False
+        domains = list(self.serv.config.get("url_preview_domains") or [])
+
+        if args.enabled is not None:
+            self.serv.config["url_previews"] = args.enabled
+            changed = True
+        if args.embed is not None:
+            self.serv.config["url_preview_embed_media"] = args.embed
+            changed = True
+        if args.clear_domains:
+            domains = []
+            changed = True
+        for d in args.allow_domain or []:
+            d = d.strip().lower().lstrip(".")
+            if d and d not in domains:
+                domains.append(d)
+                changed = True
+        for d in args.remove_domain or []:
+            d = d.strip().lower().lstrip(".")
+            if d in domains:
+                domains.remove(d)
+                changed = True
+
+        if changed:
+            self.serv.config["url_preview_domains"] = domains
+            await self.serv.save()
+            # rebuild the fetcher so changes take effect immediately
+            self.serv.init_url_preview_fetcher()
+
+        enabled = self.serv.config.get("url_previews")
+        embed = self.serv.config.get("url_preview_embed_media", True)
+        self.send_notice(f"URL previews are {'enabled' if enabled else 'disabled'}.")
+        self.send_notice(f"Inline media embedding is {'enabled' if embed else 'disabled'}.")
+        if domains:
+            self.send_notice(f"Allowed domains: {', '.join(domains)}")
+        else:
+            self.send_notice("Allowed domains: all")
 
     async def cmd_open(self, args):
         networks = self.networks()

--- a/heisenbridge/control_room.py
+++ b/heisenbridge/control_room.py
@@ -235,6 +235,12 @@ class ControlRoom(Room):
             cmd.add_argument("--allow-domain", help="restrict previews to this domain (repeatable)", action="append")
             cmd.add_argument("--remove-domain", help="remove a domain from the allowlist", action="append")
             cmd.add_argument("--clear-domains", action="store_true", help="clear the domain allowlist (allow all)")
+            cmd.add_argument(
+                "--user-agent",
+                help="override the HTTP User-Agent used when fetching previews (some sites only serve"
+                " OpenGraph tags to known crawler UAs)",
+            )
+            cmd.add_argument("--reset-user-agent", action="store_true", help="restore the default User-Agent")
             self.commands.register(cmd, self.cmd_urlpreview)
 
             cmd = CommandParser(prog="VERSION", description="show bridge version")
@@ -662,6 +668,12 @@ class ControlRoom(Room):
             if d in domains:
                 domains.remove(d)
                 changed = True
+        if args.reset_user_agent:
+            self.serv.config["url_preview_user_agent"] = None
+            changed = True
+        elif args.user_agent is not None:
+            self.serv.config["url_preview_user_agent"] = args.user_agent
+            changed = True
 
         if changed:
             self.serv.config["url_preview_domains"] = domains
@@ -669,14 +681,18 @@ class ControlRoom(Room):
             # rebuild the fetcher so changes take effect immediately
             self.serv.init_url_preview_fetcher()
 
+        from heisenbridge.url_preview import DEFAULT_USER_AGENT
+
         enabled = self.serv.config.get("url_previews")
         embed = self.serv.config.get("url_preview_embed_media", True)
+        ua = self.serv.config.get("url_preview_user_agent") or DEFAULT_USER_AGENT
         self.send_notice(f"URL previews are {'enabled' if enabled else 'disabled'}.")
         self.send_notice(f"Inline media embedding is {'enabled' if embed else 'disabled'}.")
         if domains:
             self.send_notice(f"Allowed domains: {', '.join(domains)}")
         else:
             self.send_notice("Allowed domains: all")
+        self.send_notice(f"User-Agent: {ua}")
 
     async def cmd_open(self, args):
         networks = self.networks()

--- a/heisenbridge/event_queue.py
+++ b/heisenbridge/event_queue.py
@@ -78,6 +78,11 @@ class EventQueue:
                 if "formatted_body" in prev["content"]:
                     prev_len += len(prev["content"]["formatted_body"])
 
+            # never merge events that carry their own bundled link previews,
+            # otherwise the appended body would no longer match the preview
+            prev_previews = "m.url_previews" in prev["content"] or "com.beeper.linkpreviews" in prev["content"]
+            cur_previews = "m.url_previews" in event["content"] or "com.beeper.linkpreviews" in event["content"]
+
             if (
                 prev["type"] == event["type"]
                 and prev["type"][0] != "_"
@@ -86,6 +91,8 @@ class EventQueue:
                 and prev["content"]["msgtype"] == event["content"]["msgtype"]
                 and prev_formatted == cur_formatted
                 and prev_len < 64_000  # a single IRC event can't overflow with this
+                and not prev_previews
+                and not cur_previews
             ):
                 prev["content"]["body"] += "\n" + event["content"]["body"]
                 if cur_formatted:

--- a/heisenbridge/private_room.py
+++ b/heisenbridge/private_room.py
@@ -27,6 +27,7 @@ from heisenbridge.command_parse import CommandManager
 from heisenbridge.command_parse import CommandParser
 from heisenbridge.command_parse import CommandParserError
 from heisenbridge.room import Room
+from heisenbridge.url_preview import extract_urls
 
 
 class NetworkRoom:
@@ -377,6 +378,7 @@ class PrivateRoom(Room):
     prefix_all = False
 
     commands: CommandManager
+    _preview_lock: Optional[asyncio.Lock] = None
 
     def init(self) -> None:
         self.name = None
@@ -628,12 +630,13 @@ class PrivateRoom(Room):
         ):
             self.lazy_members[irc_user_id] = event.source.nick
 
-        self.send_message(
-            plain,
-            irc_user_id,
-            formatted=formatted,
-            fallback_html=f"<b>Message from {str(event.source)}</b>: {html.escape(plain)}",
-        )
+        fallback_html = f"<b>Message from {str(event.source)}</b>: {html.escape(plain)}"
+        fetcher = getattr(self.serv, "url_preview_fetcher", None)
+        urls = extract_urls(plain) if fetcher is not None else []
+        if urls:
+            self._relay_with_previews(plain, irc_user_id, formatted, fallback_html, urls, fetcher)
+        else:
+            self.send_message(plain, irc_user_id, formatted=formatted, fallback_html=fallback_html)
 
         # lazy update displayname if we detect a change
         if (
@@ -642,6 +645,39 @@ class PrivateRoom(Room):
             and irc_user_id in self.members
         ):
             asyncio.ensure_future(self.serv.ensure_irc_user_id(self.network.name, event.source.nick))
+
+    def _relay_with_previews(self, plain, irc_user_id, formatted, fallback_html, urls, fetcher) -> None:
+        # A per-room lock keeps back-to-back messages in order even when the
+        # first one's preview fetch is slower than the second's.
+        if self._preview_lock is None:
+            self._preview_lock = asyncio.Lock()
+        asyncio.ensure_future(self._fetch_then_relay(plain, irc_user_id, formatted, fallback_html, urls, fetcher))
+
+    async def _fetch_then_relay(self, plain, irc_user_id, formatted, fallback_html, urls, fetcher) -> None:
+        previews = []
+        media = []
+        for url in urls:
+            try:
+                result = await fetcher.fetch(url)
+            except Exception:
+                logging.debug("URL preview fetch raised for %s", url, exc_info=True)
+                result = None
+            if result is None:
+                continue
+            if result.preview:
+                previews.append(result.preview)
+            if result.media:
+                media.append(result.media)
+        async with self._preview_lock:
+            self.send_message(
+                plain,
+                irc_user_id,
+                formatted=formatted,
+                fallback_html=fallback_html,
+                url_previews=previews or None,
+            )
+            for embed in media:
+                self.send_media(embed, irc_user_id, fallback_html=fallback_html)
 
     def on_privnotice(self, conn, event) -> None:
         if self.network is None:

--- a/heisenbridge/room.py
+++ b/heisenbridge/room.py
@@ -20,6 +20,21 @@ class RoomInvalidError(Exception):
     pass
 
 
+def to_beeper_preview(preview: dict) -> dict:
+    """Convert an MSC4095 preview dict to the legacy com.beeper.linkpreviews shape.
+
+    The two formats are identical except for the matched-URL key and the
+    image-encryption key, so older Beeper clients (which read the legacy key)
+    need ``matched_url`` rather than MSC4095's ``matrix:matched_url``.
+    """
+    out = dict(preview)
+    if "matrix:matched_url" in out:
+        out["matched_url"] = out.pop("matrix:matched_url")
+    if "matrix:image:encryption" in out:
+        out["beeper:image:encryption"] = out.pop("matrix:image:encryption")
+    return out
+
+
 class Room(ABC):
     az: MauService
     id: str
@@ -278,31 +293,64 @@ class Room(ABC):
 
     # send message to mx user (may be puppeted)
     def send_message(
-        self, text: str, user_id: Optional[str] = None, formatted=None, fallback_html: Optional[str] = None
+        self,
+        text: str,
+        user_id: Optional[str] = None,
+        formatted=None,
+        fallback_html: Optional[str] = None,
+        url_previews: Optional[List] = None,
     ) -> None:
         if formatted:
-            event = {
-                "type": "m.room.message",
-                "content": {
-                    "msgtype": "m.text",
-                    "format": "org.matrix.custom.html",
-                    "body": text,
-                    "formatted_body": formatted,
-                },
-                "user_id": user_id,
-                "fallback_html": fallback_html,
+            content = {
+                "msgtype": "m.text",
+                "format": "org.matrix.custom.html",
+                "body": text,
+                "formatted_body": formatted,
             }
         else:
-            event = {
-                "type": "m.room.message",
-                "content": {
-                    "msgtype": "m.text",
-                    "body": text,
-                },
-                "user_id": user_id,
-                "fallback_html": fallback_html,
+            content = {
+                "msgtype": "m.text",
+                "body": text,
             }
+        if url_previews:
+            # m.url_previews is the MSC4095 key; com.beeper.linkpreviews is the
+            # legacy key still read by current Beeper clients (different field
+            # name for the matched URL, see to_beeper_preview).
+            content["m.url_previews"] = list(url_previews)
+            content["com.beeper.linkpreviews"] = [to_beeper_preview(p) for p in url_previews]
+        event = {
+            "type": "m.room.message",
+            "content": content,
+            "user_id": user_id,
+            "fallback_html": fallback_html,
+        }
 
+        self._queue.enqueue(event)
+
+    # send inline media (m.image / m.video / m.audio) to mx user (may be puppeted)
+    def send_media(self, embed, user_id: Optional[str] = None, fallback_html: Optional[str] = None) -> None:
+        info = {}
+        if embed.mimetype:
+            info["mimetype"] = embed.mimetype
+        if embed.size:
+            info["size"] = embed.size
+        if embed.width:
+            info["w"] = embed.width
+        if embed.height:
+            info["h"] = embed.height
+        content = {
+            "msgtype": embed.msgtype,
+            "body": embed.body,
+            "url": embed.url,
+        }
+        if info:
+            content["info"] = info
+        event = {
+            "type": "m.room.message",
+            "content": content,
+            "user_id": user_id,
+            "fallback_html": fallback_html,
+        }
         self._queue.enqueue(event)
 
     # send emote to mx user (may be puppeted)

--- a/heisenbridge/url_preview.py
+++ b/heisenbridge/url_preview.py
@@ -1,0 +1,528 @@
+"""URL link previews and inline media embedding for IRC -> Matrix messages.
+
+Heisenbridge does not normally generate link previews. Matrix clients that
+implement MSC4095 (notably Beeper) render an ``m.url_previews`` array bundled
+onto ``m.room.message`` events as a rich preview card. This module:
+
+* extracts URLs from incoming IRC messages,
+* for an HTML page, scrapes OpenGraph/HTML metadata and builds a preview card
+  (uploading the og:image to the homeserver so it renders without leaking the
+  recipient's IP to the origin),
+* for a URL that points directly at a media file, downloads it and produces an
+  inline ``m.image`` / ``m.video`` / ``m.audio`` embed,
+
+with an optional per-domain allowlist so embedding can be restricted to trusted
+sources (see issue #209).
+"""
+
+import asyncio
+import logging
+import re
+import struct
+import time
+from dataclasses import dataclass
+from html import unescape
+from html.parser import HTMLParser
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Tuple
+from urllib.parse import urljoin
+from urllib.parse import urlparse
+
+import aiohttp
+
+logger = logging.getLogger(__name__)
+
+URL_RE = re.compile(r"https?://[^\s<>\"'`]+", re.IGNORECASE)
+
+DEFAULT_FETCH_TIMEOUT = 6.0
+DEFAULT_MAX_HTML_BYTES = 512 * 1024
+DEFAULT_MAX_IMAGE_BYTES = 8 * 1024 * 1024
+DEFAULT_MAX_MEDIA_BYTES = 50 * 1024 * 1024
+DEFAULT_CACHE_TTL = 30 * 60
+DEFAULT_CACHE_MAX_ENTRIES = 256
+DEFAULT_USER_AGENT = "heisenbridge-url-preview/1 (+https://github.com/hifi/heisenbridge)"
+
+# Trailing characters that are rarely part of a URL (closing paren handled
+# separately so balanced parens inside a URL are preserved).
+_TRAILING = ".,;:!?]}>’”'\""
+
+
+def extract_urls(text: str, limit: int = 4) -> List[str]:
+    """Return up to ``limit`` distinct http(s) URLs from ``text``, in order."""
+    if not text:
+        return []
+    seen = set()
+    out: List[str] = []
+    for match in URL_RE.finditer(text):
+        url = match.group(0).rstrip(_TRAILING)
+        # Strip a trailing ')' only when unbalanced, so balanced parens inside a
+        # URL (e.g. Wikipedia) survive, then clean any punctuation it exposed.
+        while url.endswith(")") and url.count("(") < url.count(")"):
+            url = url[:-1].rstrip(_TRAILING)
+        if url and url not in seen:
+            seen.add(url)
+            out.append(url)
+            if len(out) >= limit:
+                break
+    return out
+
+
+def domain_allowed(url: str, allowlist: Optional[List[str]]) -> bool:
+    """Return True if the URL's host matches the allowlist.
+
+    An empty/None allowlist allows everything. Entries match the host exactly
+    or as a parent domain (``example.com`` matches ``img.example.com``).
+    """
+    if not allowlist:
+        return True
+    host = (urlparse(url).hostname or "").lower()
+    if not host:
+        return False
+    for entry in allowlist:
+        entry = entry.strip().lower().lstrip(".")
+        if not entry:
+            continue
+        if host == entry or host.endswith("." + entry):
+            return True
+    return False
+
+
+@dataclass
+class MediaEmbed:
+    """An inline media event to send for a direct media URL."""
+
+    msgtype: str  # m.image / m.video / m.audio
+    url: str  # mxc:// URI
+    body: str  # filename / fallback text
+    mimetype: Optional[str] = None
+    size: Optional[int] = None
+    width: Optional[int] = None
+    height: Optional[int] = None
+
+
+@dataclass
+class FetchResult:
+    """Outcome of fetching a URL: a preview card and/or an inline media embed."""
+
+    preview: Optional[Dict] = None
+    media: Optional[MediaEmbed] = None
+
+    def is_empty(self) -> bool:
+        return self.preview is None and self.media is None
+
+
+class _MetaParser(HTMLParser):
+    """Extract <title> and og:/twitter:/description meta from an HTML head."""
+
+    _WANTED = frozenset(
+        {
+            "og:title",
+            "og:description",
+            "og:image",
+            "og:image:url",
+            "og:image:secure_url",
+            "og:image:width",
+            "og:image:height",
+            "og:image:alt",
+            "og:url",
+            "og:site_name",
+            "og:type",
+            "twitter:title",
+            "twitter:description",
+            "twitter:image",
+            "twitter:image:src",
+            "description",
+        }
+    )
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.meta: Dict[str, str] = {}
+        self.title: Optional[str] = None
+        self._in_title = False
+        self._title_chunks: List[str] = []
+        self._in_head = True
+
+    def handle_starttag(self, tag: str, attrs) -> None:
+        tag = tag.lower()
+        if tag == "body":
+            self._in_head = False
+            return
+        if not self._in_head:
+            return
+        if tag == "title":
+            self._in_title = True
+            return
+        if tag != "meta":
+            return
+        a = {k.lower(): (v or "") for k, v in attrs}
+        key = a.get("property") or a.get("name") or a.get("itemprop")
+        value = a.get("content")
+        if not key or value is None:
+            return
+        key = key.strip().lower()
+        if key in self._WANTED and key not in self.meta:
+            self.meta[key] = value.strip()
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag.lower() == "title":
+            self._in_title = False
+            if self._title_chunks and self.title is None:
+                self.title = unescape("".join(self._title_chunks)).strip()
+
+    def handle_data(self, data: str) -> None:
+        if self._in_title:
+            self._title_chunks.append(data)
+
+
+def parse_html_meta(html_bytes: bytes, encoding_hint: Optional[str]) -> _MetaParser:
+    text: Optional[str] = None
+    for enc in (encoding_hint, "utf-8", "latin-1"):
+        if not enc:
+            continue
+        try:
+            text = html_bytes.decode(enc, errors="replace")
+            break
+        except (LookupError, UnicodeDecodeError):
+            continue
+    if text is None:
+        text = html_bytes.decode("utf-8", errors="replace")
+    parser = _MetaParser()
+    try:
+        parser.feed(text)
+    except Exception:  # noqa: BLE001 - hostile HTML; keep whatever we parsed
+        logger.debug("HTML parser raised; using partial metadata", exc_info=True)
+    return parser
+
+
+def _pick(meta: Dict[str, str], *keys: str) -> Optional[str]:
+    for k in keys:
+        v = meta.get(k)
+        if v:
+            return v
+    return None
+
+
+async def _read_capped(resp, limit: int) -> bytes:
+    """Read up to ``limit`` decompressed bytes from an aiohttp response.
+
+    ``resp.content.read(n)`` only returns what is currently buffered (often a
+    single chunk), which truncates large pages and drops og: tags that appear
+    later in <head>. Read chunk-by-chunk until the cap or EOF.
+    """
+    chunks = []
+    total = 0
+    async for chunk in resp.content.iter_chunked(65536):
+        chunks.append(chunk)
+        total += len(chunk)
+        if total >= limit:
+            break
+    return b"".join(chunks)[:limit]
+
+
+class URLPreviewFetcher:
+    """Fetches and caches link previews / media embeds for a single AppService.
+
+    Image and media uploads go through the supplied intent (the bridge bot), so
+    the resulting mxc:// URIs live on whichever homeserver the appservice is
+    registered with — works for both Synapse and Beeper's hungryserv.
+    """
+
+    def __init__(
+        self,
+        intent,
+        *,
+        embed_media: bool = True,
+        allowed_domains: Optional[List[str]] = None,
+        fetch_timeout: float = DEFAULT_FETCH_TIMEOUT,
+        max_html_bytes: int = DEFAULT_MAX_HTML_BYTES,
+        max_image_bytes: int = DEFAULT_MAX_IMAGE_BYTES,
+        max_media_bytes: int = DEFAULT_MAX_MEDIA_BYTES,
+        cache_ttl: float = DEFAULT_CACHE_TTL,
+        cache_max_entries: int = DEFAULT_CACHE_MAX_ENTRIES,
+        user_agent: str = DEFAULT_USER_AGENT,
+    ) -> None:
+        self._intent = intent
+        self.embed_media = embed_media
+        self.allowed_domains = allowed_domains or []
+        self._timeout = aiohttp.ClientTimeout(total=fetch_timeout)
+        self._max_html_bytes = max_html_bytes
+        self._max_image_bytes = max_image_bytes
+        self._max_media_bytes = max_media_bytes
+        self._cache_ttl = cache_ttl
+        self._cache_max = cache_max_entries
+        self._user_agent = user_agent
+        self._session: Optional[aiohttp.ClientSession] = None
+        self._cache: Dict[str, Tuple[float, Optional[FetchResult]]] = {}
+        self._inflight: Dict[str, asyncio.Future] = {}
+
+    async def close(self) -> None:
+        if self._session is not None:
+            await self._session.close()
+            self._session = None
+
+    def _session_or_create(self) -> aiohttp.ClientSession:
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession(
+                timeout=self._timeout,
+                headers={
+                    "User-Agent": self._user_agent,
+                    "Accept": "text/html,application/xhtml+xml,*/*;q=0.8",
+                    "Accept-Language": "en;q=0.8, *;q=0.5",
+                },
+            )
+        return self._session
+
+    def _cache_get(self, url: str) -> Tuple[bool, Optional[FetchResult]]:
+        item = self._cache.get(url)
+        if not item:
+            return False, None
+        ts, value = item
+        if (time.monotonic() - ts) > self._cache_ttl:
+            self._cache.pop(url, None)
+            return False, None
+        return True, value
+
+    def _cache_put(self, url: str, value: Optional[FetchResult]) -> None:
+        if len(self._cache) >= self._cache_max:
+            for k in list(self._cache.keys())[: max(1, self._cache_max // 10)]:
+                self._cache.pop(k, None)
+        self._cache[url] = (time.monotonic(), value)
+
+    async def fetch(self, url: str) -> Optional[FetchResult]:
+        """Return a FetchResult for ``url`` or None if nothing useful was found."""
+        if not domain_allowed(url, self.allowed_domains):
+            logger.debug("URL %s skipped: domain not in allowlist", url)
+            return None
+
+        hit, cached = self._cache_get(url)
+        if hit:
+            return cached
+
+        fut = self._inflight.get(url)
+        if fut is not None:
+            return await fut
+
+        fut = asyncio.get_running_loop().create_future()
+        self._inflight[url] = fut
+        try:
+            result = await self._do_fetch(url)
+        except Exception:  # noqa: BLE001
+            logger.debug("URL preview failed for %s", url, exc_info=True)
+            result = None
+        finally:
+            self._inflight.pop(url, None)
+
+        if result is not None and result.is_empty():
+            result = None
+        self._cache_put(url, result)
+        if not fut.done():
+            fut.set_result(result)
+        return result
+
+    async def _do_fetch(self, url: str) -> Optional[FetchResult]:
+        session = self._session_or_create()
+        try:
+            async with session.get(url, allow_redirects=True) as resp:
+                if resp.status >= 400:
+                    return None
+                ctype = (resp.headers.get("Content-Type") or "").lower()
+                base = ctype.split(";")[0].strip()
+                final_url = str(resp.url)
+
+                if base.startswith(("image/", "video/", "audio/")):
+                    # The URL is itself a media file.
+                    return await self._direct_media(url, final_url, base, resp)
+
+                if "html" not in ctype and "xml" not in ctype:
+                    return None
+
+                body = await _read_capped(resp, self._max_html_bytes)
+                encoding = resp.charset
+        except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+            logger.debug("HTTP error for %s: %s", url, e)
+            return None
+
+        return FetchResult(preview=await self._build_card(url, final_url, body, encoding))
+
+    async def _build_card(
+        self, matched_url: str, final_url: str, body: bytes, encoding: Optional[str]
+    ) -> Optional[Dict]:
+        meta = parse_html_meta(body, encoding)
+        title = _pick(meta.meta, "og:title", "twitter:title") or meta.title
+        description = _pick(meta.meta, "og:description", "twitter:description", "description")
+        canonical = _pick(meta.meta, "og:url") or final_url
+        site_name = meta.meta.get("og:site_name")
+        image_url = _pick(
+            meta.meta,
+            "og:image",
+            "og:image:url",
+            "og:image:secure_url",
+            "twitter:image",
+            "twitter:image:src",
+        )
+
+        preview: Dict[str, object] = {"matrix:matched_url": matched_url}
+        if title:
+            preview["og:title"] = title[:400]
+        if description:
+            preview["og:description"] = description[:900]
+        if canonical:
+            preview["og:url"] = canonical
+        if site_name:
+            preview["og:site_name"] = site_name
+
+        if image_url:
+            uploaded = await self._download_and_upload(
+                urljoin(final_url, image_url), self._max_image_bytes, want_dimensions=True
+            )
+            if uploaded is not None:
+                preview["og:image"] = uploaded.url
+                if uploaded.mimetype:
+                    preview["og:image:type"] = uploaded.mimetype
+                if uploaded.size:
+                    preview["matrix:image:size"] = uploaded.size
+                if uploaded.width:
+                    preview["og:image:width"] = uploaded.width
+                if uploaded.height:
+                    preview["og:image:height"] = uploaded.height
+                alt = meta.meta.get("og:image:alt")
+                if alt:
+                    preview["og:image:alt"] = alt
+
+        if not any(k in preview for k in ("og:title", "og:description", "og:image")):
+            return None
+        return preview
+
+    async def _direct_media(self, matched_url: str, final_url: str, base: str, resp) -> Optional[FetchResult]:
+        is_image = base.startswith("image/")
+        cap = self._max_image_bytes if is_image else self._max_media_bytes
+        declared = resp.headers.get("Content-Length")
+        if declared and declared.isdigit() and int(declared) > cap:
+            return None
+        try:
+            data = await _read_capped(resp, cap + 1)
+        except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+            logger.debug("media fetch failed %s: %s", final_url, e)
+            return None
+        if len(data) > cap:
+            logger.debug("media too large, skipping: %s", final_url)
+            return None
+
+        embed = await self._upload_media_bytes(final_url, base, data)
+        if embed is None:
+            return None
+
+        # If media embedding is disabled, fall back to an image preview card so
+        # the link still gets *some* visual treatment.
+        if not self.embed_media:
+            if not is_image:
+                return None
+            return FetchResult(
+                preview={
+                    "matrix:matched_url": matched_url,
+                    "og:url": final_url,
+                    "og:title": embed.body,
+                    "og:image": embed.url,
+                    **({"og:image:type": embed.mimetype} if embed.mimetype else {}),
+                    **({"matrix:image:size": embed.size} if embed.size else {}),
+                    **({"og:image:width": embed.width} if embed.width else {}),
+                    **({"og:image:height": embed.height} if embed.height else {}),
+                }
+            )
+        return FetchResult(media=embed)
+
+    async def _download_and_upload(self, media_url: str, cap: int, want_dimensions: bool) -> Optional[MediaEmbed]:
+        session = self._session_or_create()
+        try:
+            async with session.get(media_url, allow_redirects=True) as resp:
+                if resp.status >= 400:
+                    return None
+                base = (resp.headers.get("Content-Type") or "").lower().split(";")[0].strip()
+                if not base.startswith(("image/", "video/", "audio/")):
+                    return None
+                declared = resp.headers.get("Content-Length")
+                if declared and declared.isdigit() and int(declared) > cap:
+                    return None
+                data = await _read_capped(resp, cap + 1)
+                if len(data) > cap:
+                    return None
+                final_url = str(resp.url)
+        except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+            logger.debug("media download failed %s: %s", media_url, e)
+            return None
+        return await self._upload_media_bytes(final_url, base, data)
+
+    async def _upload_media_bytes(self, source_url: str, base: str, data: bytes) -> Optional[MediaEmbed]:
+        width = height = None
+        if base.startswith("image/"):
+            try:
+                width, height = sniff_image_dimensions(data, base)
+            except Exception:  # noqa: BLE001
+                pass
+        filename = source_url.rsplit("/", 1)[-1].split("?", 1)[0] or "file"
+        try:
+            mxc = await self._intent.upload_media(data=data, mime_type=base or None, filename=filename, size=len(data))
+        except Exception:  # noqa: BLE001
+            logger.debug("media upload failed for %s", source_url, exc_info=True)
+            return None
+        msgtype = "m.image" if base.startswith("image/") else "m.video" if base.startswith("video/") else "m.audio"
+        return MediaEmbed(
+            msgtype=msgtype,
+            url=mxc,
+            body=filename,
+            mimetype=base or None,
+            size=len(data),
+            width=width,
+            height=height,
+        )
+
+
+def sniff_image_dimensions(data: bytes, ctype: str) -> Tuple[Optional[int], Optional[int]]:
+    """Cheap dimension sniffing for common formats — avoids a Pillow dependency."""
+    if ctype == "image/png" and len(data) >= 24 and data[:8] == b"\x89PNG\r\n\x1a\n":
+        width, height = struct.unpack(">II", data[16:24])
+        return width, height
+    if ctype == "image/gif" and len(data) >= 10 and data[:3] == b"GIF":
+        width, height = struct.unpack("<HH", data[6:10])
+        return width, height
+    if ctype in ("image/jpeg", "image/jpg") and data[:2] == b"\xff\xd8":
+        i, n = 2, len(data)
+        while i + 9 < n:
+            if data[i] != 0xFF:
+                return None, None
+            while i < n and data[i] == 0xFF:
+                i += 1
+            if i >= n:
+                return None, None
+            marker = data[i]
+            i += 1
+            if marker in (0xD8, 0xD9):
+                return None, None
+            if 0xD0 <= marker <= 0xD7 or marker == 0x01:
+                continue
+            if i + 1 >= n:
+                return None, None
+            seg_len = (data[i] << 8) | data[i + 1]
+            if 0xC0 <= marker <= 0xCF and marker not in (0xC4, 0xC8, 0xCC):
+                if i + 7 >= n:
+                    return None, None
+                height = (data[i + 3] << 8) | data[i + 4]
+                width = (data[i + 5] << 8) | data[i + 6]
+                return width, height
+            i += seg_len
+        return None, None
+    if ctype == "image/webp" and len(data) >= 30 and data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        fourcc = data[12:16]
+        if fourcc == b"VP8L" and len(data) >= 25:
+            b0, b1, b2, b3 = data[21], data[22], data[23], data[24]
+            width = 1 + (((b1 & 0x3F) << 8) | b0)
+            height = 1 + (((b3 & 0x0F) << 10) | (b2 << 2) | ((b1 & 0xC0) >> 6))
+            return width, height
+        if fourcc == b"VP8X" and len(data) >= 30:
+            width = 1 + (data[24] | (data[25] << 8) | (data[26] << 16))
+            height = 1 + (data[27] | (data[28] << 8) | (data[29] << 16))
+            return width, height
+    return None, None

--- a/heisenbridge/url_preview.py
+++ b/heisenbridge/url_preview.py
@@ -42,7 +42,13 @@ DEFAULT_MAX_IMAGE_BYTES = 8 * 1024 * 1024
 DEFAULT_MAX_MEDIA_BYTES = 50 * 1024 * 1024
 DEFAULT_CACHE_TTL = 30 * 60
 DEFAULT_CACHE_MAX_ENTRIES = 256
-DEFAULT_USER_AGENT = "heisenbridge-url-preview/1 (+https://github.com/hifi/heisenbridge)"
+# Many large sites (YouTube, Twitter/X, Instagram, ...) only serve the
+# lightweight server-rendered page with OpenGraph tags near the top of <head>
+# to recognised link-preview crawlers; an unknown User-Agent gets the heavy
+# JS-app variant where og: tags are buried past our read cap (or absent). Use
+# the widely-recognised Discord crawler UA by default so previews work for
+# these sites; it is overridable via config (URLPREVIEW --user-agent).
+DEFAULT_USER_AGENT = "Mozilla/5.0 (compatible; Discordbot/2.0; +https://discordapp.com)"
 
 # Trailing characters that are rarely part of a URL (closing paren handled
 # separately so balanced parens inside a URL are preserved).

--- a/tests/test_url_preview.py
+++ b/tests/test_url_preview.py
@@ -1,0 +1,93 @@
+from heisenbridge.room import to_beeper_preview
+from heisenbridge.url_preview import domain_allowed
+from heisenbridge.url_preview import extract_urls
+from heisenbridge.url_preview import parse_html_meta
+from heisenbridge.url_preview import sniff_image_dimensions
+
+
+def test_extract_urls_basic():
+    assert extract_urls("") == []
+    assert extract_urls("no links here") == []
+    assert extract_urls("see https://example.com now") == ["https://example.com"]
+    assert extract_urls("http://a.test and https://b.test") == ["http://a.test", "https://b.test"]
+
+
+def test_extract_urls_strips_trailing_punctuation():
+    assert extract_urls("look at https://example.com.") == ["https://example.com"]
+    assert extract_urls("(https://example.com)") == ["https://example.com"]
+    assert extract_urls("end: https://example.com!") == ["https://example.com"]
+    # balanced parens inside the URL are kept
+    assert extract_urls("https://en.wikipedia.org/wiki/Foo_(bar)") == ["https://en.wikipedia.org/wiki/Foo_(bar)"]
+
+
+def test_extract_urls_dedupes_and_limits():
+    assert extract_urls("https://a.test https://a.test") == ["https://a.test"]
+    many = " ".join(f"https://{i}.test" for i in range(10))
+    assert len(extract_urls(many, limit=3)) == 3
+
+
+def test_domain_allowed():
+    assert domain_allowed("https://example.com/x", None) is True
+    assert domain_allowed("https://example.com/x", []) is True
+    assert domain_allowed("https://example.com/x", ["example.com"]) is True
+    assert domain_allowed("https://img.example.com/x", ["example.com"]) is True
+    assert domain_allowed("https://evil.test/x", ["example.com"]) is False
+    # leading dot and case are normalised
+    assert domain_allowed("https://EXAMPLE.com/x", [".example.com"]) is True
+
+
+def test_parse_html_meta_opengraph():
+    html = (
+        b"<html><head>"
+        b"<title>Fallback Title</title>"
+        b'<meta property="og:title" content="OG Title">'
+        b'<meta property="og:description" content="A description">'
+        b'<meta property="og:image" content="https://example.com/img.png">'
+        b'<meta name="og:site_name" content="Example">'
+        b"</head><body>...</body></html>"
+    )
+    meta = parse_html_meta(html, "utf-8")
+    assert meta.meta["og:title"] == "OG Title"
+    assert meta.meta["og:description"] == "A description"
+    assert meta.meta["og:image"] == "https://example.com/img.png"
+    assert meta.title == "Fallback Title"
+
+
+def test_parse_html_meta_title_fallback():
+    html = b"<html><head><title>Only Title</title></head><body>x</body></html>"
+    meta = parse_html_meta(html, "utf-8")
+    assert meta.title == "Only Title"
+    assert "og:title" not in meta.meta
+
+
+def test_to_beeper_preview_renames_matched_url():
+    msc = {
+        "matrix:matched_url": "https://example.com",
+        "og:title": "T",
+        "og:image": "mxc://a/b",
+    }
+    legacy = to_beeper_preview(msc)
+    assert legacy["matched_url"] == "https://example.com"
+    assert "matrix:matched_url" not in legacy
+    assert legacy["og:title"] == "T"
+    assert legacy["og:image"] == "mxc://a/b"
+    # original is not mutated
+    assert "matrix:matched_url" in msc
+
+
+def test_sniff_png_dimensions():
+    import struct
+
+    png = b"\x89PNG\r\n\x1a\n" + b"\x00" * 8 + struct.pack(">II", 320, 240)
+    assert sniff_image_dimensions(png, "image/png") == (320, 240)
+
+
+def test_sniff_gif_dimensions():
+    import struct
+
+    gif = b"GIF89a" + struct.pack("<HH", 100, 50)
+    assert sniff_image_dimensions(gif, "image/gif") == (100, 50)
+
+
+def test_sniff_unknown_returns_none():
+    assert sniff_image_dimensions(b"not an image", "image/tiff") == (None, None)


### PR DESCRIPTION
Closes #209.

Generates link previews for URLs in messages bridged **from IRC to Matrix**, so clients that implement [MSC4095](https://github.com/matrix-org/matrix-spec-proposals/pull/4095) (e.g. Beeper) render them as rich preview cards.

### What it does

- **Web pages** → an OpenGraph/HTML preview card (`m.url_previews`). The `og:image` is fetched by the bridge and re-uploaded to the homeserver, so the preview renders without the recipient's client contacting the origin site.
- **Direct media URLs** (a link straight to an image/video/audio file) → an inline `m.image` / `m.video` / `m.audio` embed when media embedding is enabled, or an image preview card otherwise.

For client compatibility the preview is emitted under both the MSC4095 key `m.url_previews` and the legacy `com.beeper.linkpreviews` key (which uses `matched_url` instead of `matrix:matched_url`).

### Implementation

- New module `heisenbridge/url_preview.py`: URL extraction, OpenGraph/HTML scraping (stdlib `html.parser`, no new deps, `aiohttp` is already a dependency), cheap image-dimension sniffing for png/jpeg/gif/webp, an in-memory TTL cache, and per-domain allowlisting.
- `Room.send_message` gains an optional `url_previews` arg; new `Room.send_media` helper for inline embeds.
- `EventQueue` no longer merges consecutive events that carry bundled previews (the merged body would no longer match the preview).
- `PrivateRoom.on_privmsg` (covers channels via `ChannelRoom.on_pubmsg`) extracts URLs and relays through a per-room async lock so message order is preserved when a fetch is slow.
- Fetches are bounded by size and timeout and degrade gracefully to a plain message on failure.

 ### Testing

- `tests/test_url_preview.py` covers URL extraction (trailing punctuation, balanced parens, dedupe/limit), domain allowlisting, OpenGraph/title parsing, the legacy preview transform, and image-dimension sniffing.
- Manually verified end-to-end against a Beeper-hosted heisenbridge: web-page cards, direct-image embeds, and the domain allowlist all render on Beeper iOS and desktop.

### Notes for reviewers

- The og:image/media is re-uploaded via the bridge bot intent, so the resulting `mxc://` lives on whichever homeserver the appservice is registered with (works on Synapse and Beeper's hungryserv).
- Defaulting to **on** matches the bridge's "just works" spirit; easy to flip to opt-in if you'd prefer.