### PR TITLE
Relay literal /me as an IRC action

### DIFF
--- a/heisenbridge/private_room.py
+++ b/heisenbridge/private_room.py
@@ -869,6 +869,18 @@ class PrivateRoom(Room):
             self.media.append([event.event_id, event.content.url])
             await self.save()
         elif str(event.content.msgtype) == "m.text":
+            # clients that don't turn "/me ..." into a real m.emote send it as
+            # literal text, relay it as an IRC ACTION instead of a plain line
+            if event.content.body == "/me" or event.content.body.startswith("/me "):
+                event.content.body = event.content.body[len("/me") :].lstrip()
+                if event.content.formatted_body:
+                    event.content.formatted_body = re.sub(
+                        r"(^\s*(?:<[^>]+>)*)\s*/me\s*", r"\1", event.content.formatted_body, count=1
+                    )
+                await self._send_message(event, self.network.conn.action)
+                await self.az.intent.send_receipt(event.room_id, event.event_id)
+                return
+
             # allow commanding the appservice in rooms
             match = re.match(r"^\s*@?([^:,\s]+)[\s:,]*(.+)$", event.content.body)
             if match and match.group(1).lower() == self.serv.registration["sender_localpart"]:


### PR DESCRIPTION
Follow-up to #13. That closed on proper m.emote support, but Beeper sends "/me does a thing" as literal m.text instead of translating it to m.emote client-side.

Detects a leading "/me " (or bare "/me") in an m.text body and routes it through the same action() call m.emote already uses, instead of relaying it as a plain PRIVMSG containing the literal string "/me ...".