### PR TITLE
Rewrite plain-text @nick as an IRC highlight

### DIFF
--- a/heisenbridge/private_room.py
+++ b/heisenbridge/private_room.py
@@ -879,6 +879,16 @@ class PrivateRoom(Room):
                 finally:
                     return
 
+            # a plain-text "@nick ..." to an actual channel member reads as an
+            # IRC highlight, not a literal @nick
+            mention = re.match(r"^@([^\s:,]+)[\s:,]+(.+)$", event.content.body, re.DOTALL)
+            if mention and getattr(self, "is_on_channel", None) and self.is_on_channel(mention.group(1)):
+                event.content.body = f"{mention.group(1)}: {mention.group(2)}"
+                if event.content.formatted_body:
+                    fmt_mention = re.match(r"^@([^\s:,]+)[\s:,]+(.+)$", event.content.formatted_body, re.DOTALL)
+                    if fmt_mention and fmt_mention.group(1) == mention.group(1):
+                        event.content.formatted_body = f"{mention.group(1)}: {fmt_mention.group(2)}"
+
             await self._send_message(event, self.network.conn.privmsg)
 
         await self.az.intent.send_receipt(event.room_id, event.event_id)

--- a/heisenbridge/private_room.py
+++ b/heisenbridge/private_room.py
@@ -879,15 +879,30 @@ class PrivateRoom(Room):
                 finally:
                     return
 
-            # a plain-text "@nick ..." to an actual channel member reads as an
-            # IRC highlight, not a literal @nick
-            mention = re.match(r"^@([^\s:,]+)[\s:,]+(.+)$", event.content.body, re.DOTALL)
-            if mention and getattr(self, "is_on_channel", None) and self.is_on_channel(mention.group(1)):
-                event.content.body = f"{mention.group(1)}: {mention.group(2)}"
+            # a plain-text "@nick" naming an actual channel member reads as a
+            # literal @nick to IRC, strip the @ anywhere it appears so the
+            # nick highlights normally, and use "nick: " when it opens the line
+            if getattr(self, "is_on_channel", None):
+
+                def _strip_mention(m):
+                    word = m.group(1)
+                    wlen = len(word)
+                    while wlen > 0 and word[wlen - 1] in "?!:;,.":
+                        wlen -= 1
+                    nick, tail = word[:wlen], word[wlen:]
+                    return nick + tail if self.is_on_channel(nick) else m.group(0)
+
+                body = re.sub(r"(?:^|(?<=\s))@([^\s<]+)", _strip_mention, event.content.body)
+
+                lead = re.match(r"^([^\s:,]+)[\s:,]+(.+)$", body, re.DOTALL)
+                if event.content.body.startswith("@") and lead and self.is_on_channel(lead.group(1)):
+                    body = f"{lead.group(1)}: {lead.group(2)}"
+
+                event.content.body = body
                 if event.content.formatted_body:
-                    fmt_mention = re.match(r"^@([^\s:,]+)[\s:,]+(.+)$", event.content.formatted_body, re.DOTALL)
-                    if fmt_mention and fmt_mention.group(1) == mention.group(1):
-                        event.content.formatted_body = f"{mention.group(1)}: {fmt_mention.group(2)}"
+                    event.content.formatted_body = re.sub(
+                        r"(?:^|(?<=\s))@([^\s<]+)", _strip_mention, event.content.formatted_body
+                    )
 
             await self._send_message(event, self.network.conn.privmsg)
 


### PR DESCRIPTION
On Beeper, manually typing `@alice hello` (not using the client's mention autocomplete, so no pill, no m.mentions) currently relays to IRC as the literal string `@alice hello` instead of the usual IRC highlight convention `alice: hello`.

This only rewrites the message when the word right after `@` matches a nick actually on the channel right now (is_on_channel), so it never invents a mapping for a name that isn't there.

Related but distinct from two earlier threads worth reconsidering here:

- #146 wanted to strip a leading `@` from FluffyChat's specific fallback-mention text and got shelved in favor of doing mentions properly once formatted_body/pills were supported (#102, since closed). This isn't that: there's no pill, no fallback-mention markup at all, just plain manually-typed text, so the "handle it properly via #102" answer doesn't apply here.
- #195 raised concerns about mapping Matrix users to IRC nicks by displayname being ambiguous. This doesn't map anything: it only fires when the exact word is already a live nick on the channel, so there's nothing to disambiguate.

Given that, happy to discuss if this should still be opt-in via a room setting, but wanted to raise it since the earlier objections don't seem to carry over directly.